### PR TITLE
Add music releases feature with detailed pages and RSS feed integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "brylie.music",
       "version": "0.0.1",
       "dependencies": {
-        "@astro-community/astro-embed-youtube": "^0.5.10",
         "@astrojs/mdx": "^4.3.13",
         "@astrojs/rss": "^4.0.14",
         "@astrojs/sitemap": "^3.6.0",
@@ -18,6 +17,7 @@
         "@iconify-json/simple-icons": "^1.2.66",
         "@tailwindcss/vite": "^4.1.13",
         "astro": "^5.16.6",
+        "astro-embed": "^0.12.0",
         "astro-icon": "^1.1.5",
         "markdown-it": "^14.1.0",
         "sanitize-html": "^2.17.0",
@@ -50,6 +50,110 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@astro-community/astro-embed-baseline-status": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@astro-community/astro-embed-baseline-status/-/astro-embed-baseline-status-0.2.2.tgz",
+      "integrity": "sha512-07TBEb+xQWWZfMuoHohcZv/r2VSB80/1xN5iLhzSqavLmdsMyebEnbc6tvw3yMkxvX9IBLduNA5SxvVkpmowNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@astro-community/astro-embed-utils": "^0.2.0"
+      }
+    },
+    "node_modules/@astro-community/astro-embed-bluesky": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@astro-community/astro-embed-bluesky/-/astro-embed-bluesky-0.1.6.tgz",
+      "integrity": "sha512-3y6Y3cRelLnR9AYMItmEAjcr83KAEa6WvsxQ1eHq1cPBzICXknuzphaZlmQZ+QG5NTtmEJD+2lQWrFba/BfM1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@atproto/api": "^0.13.14"
+      }
+    },
+    "node_modules/@astro-community/astro-embed-gist": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@astro-community/astro-embed-gist/-/astro-embed-gist-0.1.0.tgz",
+      "integrity": "sha512-wP3EoBZZjDoPLH6TZzem8jDJxOuweDoK5zWmSra0QBKz3Lry1tZGCwKII5mlnOL2AmTKLrfqrBXTxSGwb7AimQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@astro-community/astro-embed-utils": "^0.2.0"
+      }
+    },
+    "node_modules/@astro-community/astro-embed-integration": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@astro-community/astro-embed-integration/-/astro-embed-integration-0.11.0.tgz",
+      "integrity": "sha512-xmwXN8039zUT0/lBO2GUr8cm5t/v+9Fh8QkPUhTWy+A7RR0+PwT1M3PBm8q01A1rK9q0myOyFHEcSOp+WkH5tg==",
+      "license": "MIT",
+      "dependencies": {
+        "@astro-community/astro-embed-bluesky": "^0.1.6",
+        "@astro-community/astro-embed-gist": "^0.1.0",
+        "@astro-community/astro-embed-link-preview": "^0.3.0",
+        "@astro-community/astro-embed-mastodon": "^0.1.0",
+        "@astro-community/astro-embed-twitter": "^0.5.10",
+        "@astro-community/astro-embed-vimeo": "^0.3.12",
+        "@astro-community/astro-embed-youtube": "^0.5.10",
+        "@types/unist": "^3.0.3",
+        "astro-auto-import": "^0.4.5",
+        "unist-util-select": "^5.1.0"
+      },
+      "peerDependencies": {
+        "astro": "^5.0.0 || ^6.0.0-alpha"
+      }
+    },
+    "node_modules/@astro-community/astro-embed-link-preview": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@astro-community/astro-embed-link-preview/-/astro-embed-link-preview-0.3.1.tgz",
+      "integrity": "sha512-TI++efm08+kJqxqA7bvxBr7+Zt4yCceA6s3wvAQJ87eiaxbLqAFUSQ+paQD66ET9dIC+IuKzHOMwsoDfqBidYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@astro-community/astro-embed-utils": "^0.2.0",
+        "@parse5/tools": "^0.7.0",
+        "parse5": "^8.0.0"
+      }
+    },
+    "node_modules/@astro-community/astro-embed-link-preview/node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/@astro-community/astro-embed-mastodon": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@astro-community/astro-embed-mastodon/-/astro-embed-mastodon-0.1.0.tgz",
+      "integrity": "sha512-IEgoBps2OI+Ayov77B08KVTmgMDvPLimXkUj76/po8SMc/Cjq5/2dByaOBqU/sk5brHZlacR+9ZbtO/JOoihXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@astro-community/astro-embed-utils": "^0.2.0"
+      }
+    },
+    "node_modules/@astro-community/astro-embed-twitter": {
+      "version": "0.5.11",
+      "resolved": "https://registry.npmjs.org/@astro-community/astro-embed-twitter/-/astro-embed-twitter-0.5.11.tgz",
+      "integrity": "sha512-6cmyQY4LVVJj6x7qC6XrhWcxNffLvR+QGE/iw5HTOtAn60AStr6u+IX2Txpy6N6bta0DLjGqhTBhkC3NxmVKJg==",
+      "license": "MIT",
+      "dependencies": {
+        "@astro-community/astro-embed-utils": "^0.2.0"
+      }
+    },
+    "node_modules/@astro-community/astro-embed-utils": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@astro-community/astro-embed-utils/-/astro-embed-utils-0.2.0.tgz",
+      "integrity": "sha512-Ia70AMCFOUOSoaMfMaK7Ovk7VyIY4opwzBJoA6GeL+omkvpFwDbSWmA8MOiMF4gJC0j/1dgrEir+txIb+WvsCA==",
+      "license": "MIT"
+    },
+    "node_modules/@astro-community/astro-embed-vimeo": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/@astro-community/astro-embed-vimeo/-/astro-embed-vimeo-0.3.12.tgz",
+      "integrity": "sha512-VLNcsniT5qZ/7GaSGFWnX4ar0qcGyAYB1HQnAH362Zjqs0QI2he9u1nWv1kEx4xr3fZVxl6D2QuNN4xKtd8/ig==",
+      "license": "MIT",
+      "dependencies": {
+        "@astro-community/astro-embed-utils": "^0.2.0"
       }
     },
     "node_modules/@astro-community/astro-embed-youtube": {
@@ -178,6 +282,97 @@
       },
       "engines": {
         "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+      }
+    },
+    "node_modules/@atproto/api": {
+      "version": "0.13.35",
+      "resolved": "https://registry.npmjs.org/@atproto/api/-/api-0.13.35.tgz",
+      "integrity": "sha512-vsEfBj0C333TLjDppvTdTE0IdKlXuljKSveAeI4PPx/l6eUKNnDTsYxvILtXUVzwUlTDmSRqy5O4Ryh78n1b7g==",
+      "license": "MIT",
+      "dependencies": {
+        "@atproto/common-web": "^0.4.0",
+        "@atproto/lexicon": "^0.4.6",
+        "@atproto/syntax": "^0.3.2",
+        "@atproto/xrpc": "^0.6.8",
+        "await-lock": "^2.2.2",
+        "multiformats": "^9.9.0",
+        "tlds": "^1.234.0",
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@atproto/common-web": {
+      "version": "0.4.12",
+      "resolved": "https://registry.npmjs.org/@atproto/common-web/-/common-web-0.4.12.tgz",
+      "integrity": "sha512-3aCJemqM/fkHQrVPbTCHCdiVstKFI+2LkFLvUhO6XZP0EqUZa/rg/CIZBKTFUWu9I5iYiaEiXL9VwcDRpEevSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@atproto/lex-data": "0.0.8",
+        "@atproto/lex-json": "0.0.8",
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@atproto/lex-data": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-data/-/lex-data-0.0.8.tgz",
+      "integrity": "sha512-1Y5tz7BkS7380QuLNXaE8GW8Xba+mRWugt8BKM4BUFYjjUZdmirU8lr72iM4XlEBrzRu8Cfvj+MbsbYaZv+IgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@atproto/syntax": "0.4.2",
+        "multiformats": "^9.9.0",
+        "tslib": "^2.8.1",
+        "uint8arrays": "3.0.0",
+        "unicode-segmenter": "^0.14.0"
+      }
+    },
+    "node_modules/@atproto/lex-data/node_modules/@atproto/syntax": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@atproto/syntax/-/syntax-0.4.2.tgz",
+      "integrity": "sha512-X9XSRPinBy/0VQ677j8VXlBsYSsUXaiqxWVpGGxJYsAhugdQRb0jqaVKJFtm6RskeNkV6y9xclSUi9UYG/COrA==",
+      "license": "MIT"
+    },
+    "node_modules/@atproto/lex-json": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-json/-/lex-json-0.0.8.tgz",
+      "integrity": "sha512-w1Qmkae1QhmNz+i1Zm3xr3jp0UPPRENmdlpU0qIrdxWDo9W4Mzkeyc3eSoa+Zs+zN8xkRSQw7RLZte/B7Ipdwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@atproto/lex-data": "0.0.8",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@atproto/lexicon": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@atproto/lexicon/-/lexicon-0.4.14.tgz",
+      "integrity": "sha512-jiKpmH1QER3Gvc7JVY5brwrfo+etFoe57tKPQX/SmPwjvUsFnJAow5xLIryuBaJgFAhnTZViXKs41t//pahGHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@atproto/common-web": "^0.4.2",
+        "@atproto/syntax": "^0.4.0",
+        "iso-datestring-validator": "^2.2.2",
+        "multiformats": "^9.9.0",
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@atproto/lexicon/node_modules/@atproto/syntax": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@atproto/syntax/-/syntax-0.4.2.tgz",
+      "integrity": "sha512-X9XSRPinBy/0VQ677j8VXlBsYSsUXaiqxWVpGGxJYsAhugdQRb0jqaVKJFtm6RskeNkV6y9xclSUi9UYG/COrA==",
+      "license": "MIT"
+    },
+    "node_modules/@atproto/syntax": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@atproto/syntax/-/syntax-0.3.4.tgz",
+      "integrity": "sha512-8CNmi5DipOLaVeSMPggMe7FCksVag0aO6XZy9WflbduTKM4dFZVCs4686UeMLfGRXX+X966XgwECHoLYrovMMg==",
+      "license": "MIT"
+    },
+    "node_modules/@atproto/xrpc": {
+      "version": "0.6.12",
+      "resolved": "https://registry.npmjs.org/@atproto/xrpc/-/xrpc-0.6.12.tgz",
+      "integrity": "sha512-Ut3iISNLujlmY9Gu8sNU+SPDJDvqlVzWddU8qUr0Yae5oD4SguaUFjjhireMGhQ3M5E0KljQgDbTmnBo1kIZ3w==",
+      "license": "MIT",
+      "dependencies": {
+        "@atproto/lexicon": "^0.4.10",
+        "zod": "^3.23.8"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -1415,6 +1610,15 @@
       "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
       "license": "MIT"
     },
+    "node_modules/@parse5/tools": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@parse5/tools/-/tools-0.7.0.tgz",
+      "integrity": "sha512-JDvrGhc8kYBq7/SM4obJkpgwWo6pRjF/fo9CCaiJyVOkDf203Ciq2UF6TjzCFXKs7Q/zS2sS4deyBx0XzRvh9Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "parse5": "7.x || 8.x"
+      }
+    },
     "node_modules/@rollup/pluginutils": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
@@ -2481,6 +2685,41 @@
         "sharp": "^0.34.0"
       }
     },
+    "node_modules/astro-auto-import": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/astro-auto-import/-/astro-auto-import-0.4.6.tgz",
+      "integrity": "sha512-8EgeOTChgHX6x31s2CjeOUCDuG2s0wgT9D9zXI4CxgmljEoJeCAWIq/henhdmvZ+Y103MfH7CYNw5VW7GiM6xQ==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.8.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "astro": "^2.0.0 || ^3.0.0-beta || ^4.0.0-beta || ^5.0.0-beta"
+      }
+    },
+    "node_modules/astro-embed": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/astro-embed/-/astro-embed-0.12.0.tgz",
+      "integrity": "sha512-Hp/zfIFsibBSCXEC09Lk38uYq5IJyXClbNASiT/06fqrMvgWJzPEPvtnCEo1qIw8hxIh+4+esAJoktu5YKRIEA==",
+      "license": "MIT",
+      "dependencies": {
+        "@astro-community/astro-embed-baseline-status": "^0.2.2",
+        "@astro-community/astro-embed-bluesky": "^0.1.6",
+        "@astro-community/astro-embed-gist": "^0.1.0",
+        "@astro-community/astro-embed-integration": "^0.11.0",
+        "@astro-community/astro-embed-link-preview": "^0.3.0",
+        "@astro-community/astro-embed-mastodon": "^0.1.0",
+        "@astro-community/astro-embed-twitter": "^0.5.10",
+        "@astro-community/astro-embed-vimeo": "^0.3.12",
+        "@astro-community/astro-embed-youtube": "^0.5.10"
+      },
+      "peerDependencies": {
+        "astro": "^5.0.0 || ^6.0.0-alpha"
+      }
+    },
     "node_modules/astro-icon": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/astro-icon/-/astro-icon-1.1.5.tgz",
@@ -2530,6 +2769,12 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/await-lock": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/await-lock/-/await-lock-2.2.2.tgz",
+      "integrity": "sha512-aDczADvlvTGajTDjcjpJMqRkOF6Qdz3YbPZm/PyW6tKPkx2hlYBzxMhEywM/tU72HrVZjgl5VCdRuMlA7pZ8Gw==",
       "license": "MIT"
     },
     "node_modules/axios": {
@@ -2978,6 +3223,22 @@
       "funding": {
         "url": "https://github.com/sponsors/fb55"
       }
+    },
+    "node_modules/css-selector-parser": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/css-selector-parser/-/css-selector-parser-3.3.0.tgz",
+      "integrity": "sha512-Y2asgMGFqJKF4fq4xHDSlFYIkeVfRsm69lQC1q9kbEsH5XtnINTMrweLkjYMeaUgiXBy/uvKeO/a1JHTNnmB2g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/css-tree": {
       "version": "3.1.0",
@@ -4463,6 +4724,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/iso-datestring-validator": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/iso-datestring-validator/-/iso-datestring-validator-2.2.2.tgz",
+      "integrity": "sha512-yLEMkBbLZTlVQqOnQ4FiMujR6T4DEcCb1xizmvXS+OxuhwcbtynoosRzdMA69zZCShCNAbi+gJ71FxZBBXx1SA==",
+      "license": "MIT"
     },
     "node_modules/jiti": {
       "version": "2.5.1",
@@ -6025,6 +6292,12 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/multiformats": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
+      "license": "(Apache-2.0 AND MIT)"
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -7315,6 +7588,15 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tlds": {
+      "version": "1.261.0",
+      "resolved": "https://registry.npmjs.org/tlds/-/tlds-1.261.0.tgz",
+      "integrity": "sha512-QXqwfEl9ddlGBaRFXIvNKK6OhipSiLXuRuLJX5DErz0o0Q0rYxulWLdFryTkV5PkdZct5iMInwYEGe/eR++1AA==",
+      "license": "MIT",
+      "bin": {
+        "tlds": "bin.js"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -7412,6 +7694,15 @@
       "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
       "license": "MIT"
     },
+    "node_modules/uint8arrays": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.0.0.tgz",
+      "integrity": "sha512-HRCx0q6O9Bfbp+HHSfQQKD7wU70+lydKVt4EghkdOvlK/NlrF90z+eXV34mUd48rNvVJXwkrMSPpCATkct8fJA==",
+      "license": "MIT",
+      "dependencies": {
+        "multiformats": "^9.4.2"
+      }
+    },
     "node_modules/ultrahtml": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/ultrahtml/-/ultrahtml-1.6.0.tgz",
@@ -7448,6 +7739,12 @@
         "base64-js": "^1.3.0",
         "unicode-trie": "^2.0.0"
       }
+    },
+    "node_modules/unicode-segmenter": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/unicode-segmenter/-/unicode-segmenter-0.14.5.tgz",
+      "integrity": "sha512-jHGmj2LUuqDcX3hqY12Ql+uhUTn8huuxNZGq7GvtF6bSybzH3aFgedYu/KTzQStEgt1Ra2F3HxadNXsNjb3m3g==",
+      "license": "MIT"
     },
     "node_modules/unicode-trie": {
       "version": "2.0.0",
@@ -7564,6 +7861,23 @@
       "dependencies": {
         "@types/unist": "^3.0.0",
         "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-select": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-select/-/unist-util-select-5.1.0.tgz",
+      "integrity": "sha512-4A5mfokSHG/rNQ4g7gSbdEs+H586xyd24sdJqF1IWamqrLHvYb+DH48fzxowyOhOfK7YSqX+XlCojAyuuyyT2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "css-selector-parser": "^3.0.0",
+        "devlop": "^1.1.0",
+        "nth-check": "^2.0.0",
+        "zwitch": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,14 @@
       "name": "brylie.music",
       "version": "0.0.1",
       "dependencies": {
+        "@astro-community/astro-embed-youtube": "^0.5.10",
         "@astrojs/mdx": "^4.3.13",
         "@astrojs/rss": "^4.0.14",
         "@astrojs/sitemap": "^3.6.0",
         "@fontsource/atkinson-hyperlegible": "^5.2.7",
         "@iconify-json/material-symbols": "^1.2.34",
         "@iconify-json/mdi": "^1.2.3",
+        "@iconify-json/simple-icons": "^1.2.66",
         "@tailwindcss/vite": "^4.1.13",
         "astro": "^5.16.6",
         "astro-icon": "^1.1.5",
@@ -24,6 +26,7 @@
       },
       "devDependencies": {
         "@tailwindcss/typography": "^0.5.16",
+        "@types/markdown-it": "^14.1.2",
         "unplugin-fonts": "^1.4.0"
       }
     },
@@ -47,6 +50,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@astro-community/astro-embed-youtube": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/@astro-community/astro-embed-youtube/-/astro-embed-youtube-0.5.10.tgz",
+      "integrity": "sha512-hVlx77KQLjKzElVQnrU5znQ5/E60keVSAPrhuWvQQHuqva5auJtt8YBpOThkwDMuEKXjQybEF1/3C07RZ8MAOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lite-youtube-embed": "^0.3.4"
       }
     },
     "node_modules/@astrojs/compiler": {
@@ -675,6 +687,15 @@
       "resolved": "https://registry.npmjs.org/@iconify-json/mdi/-/mdi-1.2.3.tgz",
       "integrity": "sha512-O3cLwbDOK7NNDf2ihaQOH5F9JglnulNDFV7WprU2dSoZu3h3cWH//h74uQAB87brHmvFVxIOkuBX2sZSzYhScg==",
       "license": "Apache-2.0",
+      "dependencies": {
+        "@iconify/types": "*"
+      }
+    },
+    "node_modules/@iconify-json/simple-icons": {
+      "version": "1.2.66",
+      "resolved": "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.66.tgz",
+      "integrity": "sha512-D1OnnXwiQXFkVMw5M+Bt8mPsXeMkQyGmMdrmN7lsQlKMUkfLOp6JWhnUJ92po51WXT046aF/zzqSmkKqg08p4Q==",
+      "license": "CC0-1.0",
       "dependencies": {
         "@iconify/types": "*"
       }
@@ -2100,6 +2121,24 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
@@ -2108,6 +2147,13 @@
       "dependencies": {
         "@types/unist": "*"
       }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/mdx": {
       "version": "2.0.13",
@@ -4681,6 +4727,12 @@
       "dependencies": {
         "uc.micro": "^2.0.0"
       }
+    },
+    "node_modules/lite-youtube-embed": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/lite-youtube-embed/-/lite-youtube-embed-0.3.4.tgz",
+      "integrity": "sha512-aXgxpwK7AIW58GEbRzA8EYaY4LWvF3FKak6B9OtSJmuNyLhX2ouD4cMTxz/yR5HFInhknaYd2jLWOTRTvT8oAw==",
+      "license": "Apache-2.0"
     },
     "node_modules/local-pkg": {
       "version": "0.5.1",

--- a/package.json
+++ b/package.json
@@ -9,12 +9,14 @@
     "astro": "astro"
   },
   "dependencies": {
+    "@astro-community/astro-embed-youtube": "^0.5.10",
     "@astrojs/mdx": "^4.3.13",
     "@astrojs/rss": "^4.0.14",
     "@astrojs/sitemap": "^3.6.0",
     "@fontsource/atkinson-hyperlegible": "^5.2.7",
     "@iconify-json/material-symbols": "^1.2.34",
     "@iconify-json/mdi": "^1.2.3",
+    "@iconify-json/simple-icons": "^1.2.66",
     "@tailwindcss/vite": "^4.1.13",
     "astro": "^5.16.6",
     "astro-icon": "^1.1.5",
@@ -25,6 +27,7 @@
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.16",
+    "@types/markdown-it": "^14.1.2",
     "unplugin-fonts": "^1.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "astro": "astro"
   },
   "dependencies": {
-    "@astro-community/astro-embed-youtube": "^0.5.10",
     "@astrojs/mdx": "^4.3.13",
     "@astrojs/rss": "^4.0.14",
     "@astrojs/sitemap": "^3.6.0",
@@ -19,6 +18,7 @@
     "@iconify-json/simple-icons": "^1.2.66",
     "@tailwindcss/vite": "^4.1.13",
     "astro": "^5.16.6",
+    "astro-embed": "^0.12.0",
     "astro-icon": "^1.1.5",
     "markdown-it": "^14.1.0",
     "sanitize-html": "^2.17.0",

--- a/src/components/LicenseBadge.astro
+++ b/src/components/LicenseBadge.astro
@@ -22,7 +22,7 @@ const { type, version } = parseLicense(license);
 
 // Generate license URL from SPDX identifier
 const getLicenseUrl = (spdx: string) => {
-  const normalized = spdx.toLowerCase().replace("cc-", "").replace("-", "/");
+  const normalized = spdx.toLowerCase().replace(/^cc-/i, "").replace(/-/g, "/");
   return `https://creativecommons.org/licenses/${normalized}/`;
 };
 

--- a/src/components/LicenseBadge.astro
+++ b/src/components/LicenseBadge.astro
@@ -1,5 +1,6 @@
 ---
 import { Icon } from "astro-icon/components";
+import { buildLicenseUrl } from "../utils/license";
 
 interface Props {
   license: string;
@@ -20,13 +21,7 @@ const parseLicense = (spdx: string) => {
 
 const { type, version } = parseLicense(license);
 
-// Generate license URL from SPDX identifier
-const getLicenseUrl = (spdx: string) => {
-  const normalized = spdx.toLowerCase().replace(/^cc-/i, "").replace(/-/g, "/");
-  return `https://creativecommons.org/licenses/${normalized}/`;
-};
-
-const licenseUrl = getLicenseUrl(license);
+const licenseUrl = buildLicenseUrl(license);
 const ariaLabel = `Licensed under Creative Commons ${type} ${version}`;
 ---
 

--- a/src/components/LicenseBadge.astro
+++ b/src/components/LicenseBadge.astro
@@ -1,0 +1,43 @@
+---
+import { Icon } from "astro-icon/components";
+
+interface Props {
+  license: string;
+  size?: number;
+}
+
+const { license, size = 20 } = Astro.props;
+
+// Parse SPDX license identifier (e.g., "CC-BY-4.0" -> "BY 4.0")
+const parseLicense = (spdx: string) => {
+  const match = spdx.match(/CC-(.+)-(\d+\.\d+)/i);
+  if (!match) return { type: "CC", version: "4.0" };
+  return {
+    type: match[1].toUpperCase(),
+    version: match[2],
+  };
+};
+
+const { type, version } = parseLicense(license);
+
+// Generate license URL from SPDX identifier
+const getLicenseUrl = (spdx: string) => {
+  const normalized = spdx.toLowerCase().replace("cc-", "").replace("-", "/");
+  return `https://creativecommons.org/licenses/${normalized}/`;
+};
+
+const licenseUrl = getLicenseUrl(license);
+const ariaLabel = `Licensed under Creative Commons ${type} ${version}`;
+---
+
+<a
+  href={licenseUrl}
+  target="_blank"
+  rel="license noopener noreferrer"
+  class="inline-flex items-center gap-2 text-gray-300 hover:text-blue-300 transition-colors"
+  aria-label={ariaLabel}
+  title={ariaLabel}
+>
+  <Icon name="simple-icons:creativecommons" size={size} />
+  <span class="text-sm font-medium">CC {type} {version}</span>
+</a>

--- a/src/components/NavigationMenu.astro
+++ b/src/components/NavigationMenu.astro
@@ -17,6 +17,7 @@ import { Icon } from "astro-icon/components";
   <!-- Desktop Navigation -->
   <div class="hidden md:flex items-center space-x-6">
     <HeaderLink href="/">Home</HeaderLink>
+    <HeaderLink href="/releases">Releases</HeaderLink>
     <!-- <HeaderLink href="/blog">Blog</HeaderLink> -->
     <HeaderLink href="/about">About</HeaderLink>
     <HeaderLink href="/performances">Performances</HeaderLink>
@@ -37,7 +38,8 @@ import { Icon } from "astro-icon/components";
   <div class="hidden md:flex items-center space-x-3">
     <a
       href="https://freemusicarchive.org/music/Brylie_Christopher_Oxley/"
-      target="_blank" rel="noopener noreferrer"
+      target="_blank"
+      rel="noopener noreferrer"
       title="Free Music Archive"
       class="text-gray-400 hover:text-blue-400 transition-colors p-1"
     >
@@ -46,7 +48,8 @@ import { Icon } from "astro-icon/components";
     </a>
     <a
       href="https://brylie.bandcamp.com"
-      target="_blank" rel="noopener noreferrer"
+      target="_blank"
+      rel="noopener noreferrer"
       title="Bandcamp"
       class="text-gray-400 hover:text-blue-400 transition-colors p-1"
     >
@@ -55,7 +58,8 @@ import { Icon } from "astro-icon/components";
     </a>
     <a
       href="https://open.spotify.com/artist/5QEaapYiiiIH65gfhBgsv7"
-      target="_blank" rel="noopener noreferrer"
+      target="_blank"
+      rel="noopener noreferrer"
       title="Spotify"
       class="text-gray-400 hover:text-blue-400 transition-colors p-1"
     >
@@ -64,7 +68,8 @@ import { Icon } from "astro-icon/components";
     </a>
     <a
       href="https://music.apple.com/fi/artist/brylie-christopher/1841347105"
-      target="_blank" rel="noopener noreferrer"
+      target="_blank"
+      rel="noopener noreferrer"
       title="Apple Music"
       class="text-gray-400 hover:text-blue-400 transition-colors p-1"
     >
@@ -73,7 +78,8 @@ import { Icon } from "astro-icon/components";
     </a>
     <a
       href="https://www.instagram.com/brylie.music"
-      target="_blank" rel="noopener noreferrer"
+      target="_blank"
+      rel="noopener noreferrer"
       title="Instagram"
       class="text-gray-400 hover:text-blue-400 transition-colors p-1"
     >
@@ -82,7 +88,8 @@ import { Icon } from "astro-icon/components";
     </a>
     <a
       href="https://soundcloud.com/brylie"
-      target="_blank" rel="noopener noreferrer"
+      target="_blank"
+      rel="noopener noreferrer"
       title="SoundCloud"
       class="text-gray-400 hover:text-blue-400 transition-colors p-1"
     >
@@ -91,7 +98,8 @@ import { Icon } from "astro-icon/components";
     </a>
     <a
       href="https://youtube.com/@brylie_music"
-      target="_blank" rel="noopener noreferrer"
+      target="_blank"
+      rel="noopener noreferrer"
       title="YouTube"
       class="text-gray-400 hover:text-blue-400 transition-colors p-1"
     >
@@ -108,6 +116,7 @@ import { Icon } from "astro-icon/components";
 >
   <div class="px-4 py-3 space-y-3">
     <HeaderLink href="/" class="block w-full">Home</HeaderLink>
+    <HeaderLink href="/releases" class="block w-full">Releases</HeaderLink>
     <!-- <HeaderLink href="/blog" class="block w-full">Blog</HeaderLink> -->
     <HeaderLink href="/about" class="block w-full">About</HeaderLink>
     <HeaderLink href="/performances" class="block w-full"
@@ -120,7 +129,8 @@ import { Icon } from "astro-icon/components";
     >
       <a
         href="https://freemusicarchive.org/music/Brylie_Christopher_Oxley/"
-        target="_blank" rel="noopener noreferrer"
+        target="_blank"
+        rel="noopener noreferrer"
         title="Free Music Archive"
         class="text-gray-400 hover:text-blue-400 transition-colors p-1"
       >
@@ -129,7 +139,8 @@ import { Icon } from "astro-icon/components";
       </a>
       <a
         href="https://brylie.bandcamp.com"
-        target="_blank" rel="noopener noreferrer"
+        target="_blank"
+        rel="noopener noreferrer"
         title="Bandcamp"
         class="text-gray-400 hover:text-blue-400 transition-colors p-1"
       >
@@ -138,7 +149,8 @@ import { Icon } from "astro-icon/components";
       </a>
       <a
         href="https://open.spotify.com/artist/5QEaapYiiiIH65gfhBgsv7"
-        target="_blank" rel="noopener noreferrer"
+        target="_blank"
+        rel="noopener noreferrer"
         title="Spotify"
         class="text-gray-400 hover:text-blue-400 transition-colors p-1"
       >
@@ -147,7 +159,8 @@ import { Icon } from "astro-icon/components";
       </a>
       <a
         href="https://music.apple.com/fi/artist/brylie-christopher/1841347105"
-        target="_blank" rel="noopener noreferrer"
+        target="_blank"
+        rel="noopener noreferrer"
         title="Apple Music"
         class="text-gray-400 hover:text-blue-400 transition-colors p-1"
       >
@@ -156,7 +169,8 @@ import { Icon } from "astro-icon/components";
       </a>
       <a
         href="https://www.instagram.com/brylie.music"
-        target="_blank" rel="noopener noreferrer"
+        target="_blank"
+        rel="noopener noreferrer"
         title="Instagram"
         class="text-gray-400 hover:text-blue-400 transition-colors p-1"
       >
@@ -165,7 +179,8 @@ import { Icon } from "astro-icon/components";
       </a>
       <a
         href="https://soundcloud.com/brylie"
-        target="_blank" rel="noopener noreferrer"
+        target="_blank"
+        rel="noopener noreferrer"
         title="SoundCloud"
         class="text-gray-400 hover:text-blue-400 transition-colors p-1"
       >
@@ -174,7 +189,8 @@ import { Icon } from "astro-icon/components";
       </a>
       <a
         href="https://youtube.com/@brylie_music"
-        target="_blank" rel="noopener noreferrer"
+        target="_blank"
+        rel="noopener noreferrer"
         title="YouTube"
         class="text-gray-400 hover:text-blue-400 transition-colors p-1"
       >

--- a/src/components/ReleaseCard.astro
+++ b/src/components/ReleaseCard.astro
@@ -1,0 +1,122 @@
+---
+import { Icon } from "astro-icon/components";
+import FormattedDate from "./FormattedDate.astro";
+import LicenseBadge from "./LicenseBadge.astro";
+import type { CollectionEntry } from "astro:content";
+
+interface Props {
+  release: CollectionEntry<"releases">;
+}
+
+const { release } = Astro.props;
+const { data } = release;
+
+// Get slug from urlSlug or use release.id (filename without extension)
+const slug = data.urlSlug || release.id;
+
+// Platform icons mapping (alphabetically ordered)
+const platforms = [
+  { key: "appleMusic", icon: "mdi:apple", label: "Apple Music" },
+  { key: "bandcamp", icon: "mdi:bandcamp", label: "Bandcamp" },
+  { key: "fma", icon: "mdi:music-circle", label: "Free Music Archive" },
+  { key: "soundcloud", icon: "mdi:soundcloud", label: "SoundCloud" },
+  { key: "spotify", icon: "mdi:spotify", label: "Spotify" },
+  { key: "youtube", icon: "mdi:youtube", label: "YouTube Music" },
+] as const;
+
+// Generate schema.org MusicAlbum JSON-LD
+const schemaOrg = {
+  "@context": "https://schema.org",
+  "@type": "MusicAlbum",
+  name: data.title,
+  description: data.description,
+  byArtist: {
+    "@type": "Person",
+    name: data.artist || "Brylie Christopher",
+  },
+  datePublished: data.releaseDate.toISOString().split("T")[0],
+  genre: data.genre?.join(", "),
+  license:
+    data.licenseUrl ||
+    `https://creativecommons.org/licenses/${data.license.toLowerCase().replace("cc-", "").replace("-", "/")}/`,
+  url: `/releases/${slug}/`,
+};
+---
+
+<article
+  class="bg-gray-800 rounded-lg p-6 hover:shadow-xl transition-shadow"
+  itemscope
+  itemtype="https://schema.org/MusicAlbum"
+>
+  <script type="application/ld+json" set:html={JSON.stringify(schemaOrg)} />
+
+  {
+    data.coverImage && (
+      <div class="mb-4">
+        <img
+          src={data.coverImage.src}
+          alt={`${data.title} cover art`}
+          class="w-full aspect-square object-cover rounded-lg"
+          itemprop="image"
+        />
+      </div>
+    )
+  }
+
+  <h3 class="text-xl font-semibold text-blue-300 mb-2" itemprop="name">
+    <a
+      href={`/releases/${slug}/`}
+      class="hover:text-blue-200 transition-colors"
+      itemprop="url"
+    >
+      {data.title}
+    </a>
+  </h3>
+
+  <div class="text-gray-400 text-sm mb-3">
+    <FormattedDate date={data.releaseDate} />
+  </div>
+
+  <p class="text-gray-200 mb-4" itemprop="description">
+    {data.description}
+  </p>
+
+  <div class="flex items-center justify-between flex-wrap gap-4">
+    <div class="flex-shrink-0">
+      <LicenseBadge license={data.license} size={18} />
+    </div>
+
+    {
+      data.streamingLinks && (
+        <div
+          class="flex items-center gap-3 flex-wrap"
+          role="list"
+          aria-label="Streaming platforms"
+        >
+          {platforms.map(({ key, icon, label }) => {
+            const url = data.streamingLinks?.[key];
+            if (!url) return null;
+
+            return (
+              <a
+                href={url}
+                target="_blank"
+                rel="noopener noreferrer"
+                class="text-gray-300 hover:text-blue-300 transition-colors inline-flex items-center gap-2"
+                aria-label={`Listen on ${label}`}
+                title={`Listen on ${label}`}
+                role="listitem"
+              >
+                <Icon name={icon} size={24} aria-hidden="true" />
+                <span class="hidden md:inline text-sm">{label}</span>
+              </a>
+            );
+          })}
+        </div>
+      )
+    }
+  </div>
+
+  <meta itemprop="datePublished" content={data.releaseDate.toISOString()} />
+  {data.genre && <meta itemprop="genre" content={data.genre.join(", ")} />}
+</article>

--- a/src/components/ReleaseCard.astro
+++ b/src/components/ReleaseCard.astro
@@ -3,6 +3,7 @@ import { Icon } from "astro-icon/components";
 import FormattedDate from "./FormattedDate.astro";
 import LicenseBadge from "./LicenseBadge.astro";
 import type { CollectionEntry } from "astro:content";
+import { buildLicenseUrl } from "../utils/license";
 
 interface Props {
   release: CollectionEntry<"releases">;
@@ -25,9 +26,7 @@ const platforms = [
 ] as const;
 
 // Generate schema.org MusicAlbum JSON-LD with enhanced metadata
-const licenseUrl =
-  data.licenseUrl ||
-  `https://creativecommons.org/licenses/${data.license.toLowerCase().replace("cc-", "").replace(/^by/, "by").replace("-", "/")}/`;
+const licenseUrl = data.licenseUrl || buildLicenseUrl(data.license);
 
 const schemaOrg = {
   "@context": "https://schema.org",

--- a/src/components/ReleaseCard.astro
+++ b/src/components/ReleaseCard.astro
@@ -24,22 +24,43 @@ const platforms = [
   { key: "youtube", icon: "mdi:youtube", label: "YouTube Music" },
 ] as const;
 
-// Generate schema.org MusicAlbum JSON-LD
+// Generate schema.org MusicAlbum JSON-LD with enhanced metadata
+const licenseUrl =
+  data.licenseUrl ||
+  `https://creativecommons.org/licenses/${data.license.toLowerCase().replace("cc-", "").replace(/^by/, "by").replace("-", "/")}/`;
+
 const schemaOrg = {
   "@context": "https://schema.org",
   "@type": "MusicAlbum",
   name: data.title,
   description: data.description,
   byArtist: {
-    "@type": "Person",
+    "@type": "MusicGroup",
     name: data.artist || "Brylie Christopher",
+    url: new URL("/", Astro.site || Astro.url.origin).href,
   },
   datePublished: data.releaseDate.toISOString().split("T")[0],
-  genre: data.genre?.join(", "),
-  license:
-    data.licenseUrl ||
-    `https://creativecommons.org/licenses/${data.license.toLowerCase().replace("cc-", "").replace("-", "/")}/`,
-  url: `/releases/${slug}/`,
+  genre: data.genre,
+  license: licenseUrl,
+  url: new URL(`/releases/${slug}/`, Astro.site || Astro.url.origin).href,
+  albumReleaseType:
+    data.releaseType === "EP"
+      ? "EPRelease"
+      : data.releaseType === "single"
+        ? "SingleRelease"
+        : "AlbumRelease",
+  ...(data.downloadUrl && {
+    offers: {
+      "@type": "Offer",
+      availability: "https://schema.org/InStock",
+      price: "0",
+      priceCurrency: "USD",
+      url: data.downloadUrl,
+    },
+  }),
+  ...(data.coverImage && {
+    image: new URL(data.coverImage.src, Astro.site || Astro.url.origin).href,
+  }),
 };
 ---
 
@@ -119,4 +140,6 @@ const schemaOrg = {
 
   <meta itemprop="datePublished" content={data.releaseDate.toISOString()} />
   {data.genre && <meta itemprop="genre" content={data.genre.join(", ")} />}
+  {data.license && <link itemprop="license" href={licenseUrl} />}
+  {data.artist && <meta itemprop="byArtist" content={data.artist} />}
 </article>

--- a/src/components/ReleaseCard.astro
+++ b/src/components/ReleaseCard.astro
@@ -43,9 +43,9 @@ const schemaOrg = {
   license: licenseUrl,
   url: new URL(`/releases/${slug}/`, Astro.site || Astro.url.origin).href,
   albumReleaseType:
-    data.releaseType === "EP"
+    data.releaseType?.toLowerCase() === "ep"
       ? "EPRelease"
-      : data.releaseType === "single"
+      : data.releaseType?.toLowerCase() === "single"
         ? "SingleRelease"
         : "AlbumRelease",
   ...(data.downloadUrl && {

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -20,4 +20,74 @@ const blog = defineCollection({
 		}),
 });
 
-export const collections = { blog };
+const releases = defineCollection({
+	// Load Markdown and MDX files in the `src/content/releases/` directory.
+	loader: glob({ base: './src/content/releases', pattern: '**/*.{md,mdx}' }),
+	// Type-check frontmatter for music releases
+	schema: ({ image }) =>
+		z.object({
+			// Core metadata
+			title: z.string(),
+			description: z.string(),
+			releaseDate: z.coerce.date(),
+
+			// Album classification
+			releaseType: z.enum(['album', 'ep', 'single', 'compilation']),
+			genre: z.array(z.string()).optional(),
+
+			// Creative Commons licensing (SPDX identifier)
+			license: z.string().default('CC-BY-4.0'),
+			licenseUrl: z.string().url().optional(),
+
+			// Optional custom URL slug (defaults to kebab-case title)
+			urlSlug: z.string().optional(),
+
+			// Visual assets
+			coverImage: image().optional(),
+			ogImage: image().optional(),
+
+			// Artist info
+			artist: z.string().default('Brylie Christopher'),
+
+			// Streaming platform links (alphabetically ordered)
+			streamingLinks: z
+				.object({
+					appleMusic: z.string().url().optional(),
+					bandcamp: z.string().url().optional(),
+					fma: z.string().url().optional(), // Free Music Archive
+					soundcloud: z.string().url().optional(),
+					spotify: z.string().url().optional(),
+					youtube: z.string().url().optional(),
+				})
+				.optional(),
+
+			// YouTube video embed
+			youtubeVideoId: z.string().optional(),
+
+			// Track listing
+			tracks: z
+				.array(
+					z.object({
+						title: z.string(),
+						duration: z.string(), // Human-readable format "4:32"
+					}),
+				)
+				.optional(),
+
+			// Optional metadata
+			collaborators: z.array(z.string()).optional(),
+			recordLabel: z.string().optional(),
+			catalogNumber: z.string().optional(),
+
+			// Download info (for RSS enclosure)
+			downloadUrl: z.string().url().optional(),
+			downloadSize: z.number().optional(), // Size in bytes
+			downloadMimeType: z.string().optional(), // e.g., "audio/mpeg"
+
+			// SEO fields
+			keywords: z.array(z.string()).optional(),
+			canonicalURL: z.string().url().optional(),
+		}),
+});
+
+export const collections = { blog, releases };

--- a/src/content/releases/epicycles.md
+++ b/src/content/releases/epicycles.md
@@ -11,7 +11,6 @@ streamingLinks:
   soundcloud: "https://soundcloud.com/brylie/sets/epicycles"
   appleMusic: "https://music.apple.com/gb/album/epicycles/1747536355"
   spotify: "https://open.spotify.com/album/5zRjXYgK3iuhiqGKLReFQc"
-downloadUrl: "https://freemusicarchive.org/music/Brylie_Christopher_Oxley/epicycles"
 ---
 
 Cyclical patterns and recurring musical themes that explore repetition, variation, and the mathematical beauty of orbital motion translated into sound.

--- a/src/content/releases/epicycles.md
+++ b/src/content/releases/epicycles.md
@@ -1,12 +1,17 @@
 ---
 title: "Epicycles"
 description: "Cyclical patterns and recurring musical themes"
-releaseDate: 2024-02-01
+releaseDate: 2024-05-09
 releaseType: "album"
 genre: ["ambient", "electronic", "minimal"]
 license: "CC-BY-4.0"
 streamingLinks:
+  bandcamp: "https://brylie.bandcamp.com/album/epicycles"
+  fma: "https://freemusicarchive.org/music/Brylie_Christopher_Oxley/epicycles"
   soundcloud: "https://soundcloud.com/brylie/sets/epicycles"
+  appleMusic: "https://music.apple.com/gb/album/epicycles/1747536355"
+  spotify: "https://open.spotify.com/album/5zRjXYgK3iuhiqGKLReFQc"
+downloadUrl: "https://freemusicarchive.org/music/Brylie_Christopher_Oxley/epicycles"
 ---
 
 Cyclical patterns and recurring musical themes that explore repetition, variation, and the mathematical beauty of orbital motion translated into sound.

--- a/src/content/releases/epicycles.md
+++ b/src/content/releases/epicycles.md
@@ -1,0 +1,12 @@
+---
+title: "Epicycles"
+description: "Cyclical patterns and recurring musical themes"
+releaseDate: 2024-02-01
+releaseType: "album"
+genre: ["ambient", "electronic", "minimal"]
+license: "CC-BY-4.0"
+streamingLinks:
+  soundcloud: "https://soundcloud.com/brylie/sets/epicycles"
+---
+
+Cyclical patterns and recurring musical themes that explore repetition, variation, and the mathematical beauty of orbital motion translated into sound.

--- a/src/content/releases/gentle-hearts.md
+++ b/src/content/releases/gentle-hearts.md
@@ -4,10 +4,9 @@ description: "Debut release featuring ambient electronic and minimal soundscapes
 releaseDate: 2018-07-08
 releaseType: "ep"
 genre: ["ambient electronic", "minimal electronic", "IDM"]
-license: "CC-BY"
+license: "CC-BY-4.0"
 streamingLinks:
   fma: "https://freemusicarchive.org/music/Brylie_Christopher_Oxley/Gentle_Hearts_EP"
-downloadUrl: "https://freemusicarchive.org/music/Brylie_Christopher_Oxley/Gentle_Hearts_EP"
 ---
 
 My debut release exploring gentle ambient electronic textures and minimal soundscapes with intelligent dance music influences.

--- a/src/content/releases/gentle-hearts.md
+++ b/src/content/releases/gentle-hearts.md
@@ -1,0 +1,13 @@
+---
+title: "Gentle Hearts EP"
+description: "Debut release featuring ambient electronic and minimal soundscapes"
+releaseDate: 2018-07-08
+releaseType: "ep"
+genre: ["ambient electronic", "minimal electronic", "IDM"]
+license: "CC-BY"
+streamingLinks:
+  fma: "https://freemusicarchive.org/music/Brylie_Christopher_Oxley/Gentle_Hearts_EP"
+downloadUrl: "https://freemusicarchive.org/music/Brylie_Christopher_Oxley/Gentle_Hearts_EP"
+---
+
+My debut release exploring gentle ambient electronic textures and minimal soundscapes with intelligent dance music influences.

--- a/src/content/releases/itse.md
+++ b/src/content/releases/itse.md
@@ -1,0 +1,17 @@
+---
+title: "Itse"
+description: "Celebrating self-reliance and independence while remaining open to connections with others"
+releaseDate: 2023-08-13
+releaseType: "ep"
+genre: ["electronic", "ambient", "experimental"]
+license: "CC-BY-4.0"
+streamingLinks:
+  soundcloud: "https://soundcloud.com/brylie/sets/itse"
+  fma: "https://freemusicarchive.org/music/Brylie_Christopher_Oxley/itse"
+  bandcamp: "https://brylie.bandcamp.com/album/itse"
+  appleMusic: "https://music.apple.com/fi/album/itse-ep/1703912054"
+  spotify: "https://open.spotify.com/album/1LOX3bMGNczudJzjrtaA32"
+downloadUrl: "https://freemusicarchive.org/music/Brylie_Christopher_Oxley/itse"
+---
+
+"Itse" celebrates self-reliance and independence while remaining open to connections with others.

--- a/src/content/releases/itse.md
+++ b/src/content/releases/itse.md
@@ -11,7 +11,6 @@ streamingLinks:
   bandcamp: "https://brylie.bandcamp.com/album/itse"
   appleMusic: "https://music.apple.com/fi/album/itse-ep/1703912054"
   spotify: "https://open.spotify.com/album/1LOX3bMGNczudJzjrtaA32"
-downloadUrl: "https://freemusicarchive.org/music/Brylie_Christopher_Oxley/itse"
 ---
 
 "Itse" celebrates self-reliance and independence while remaining open to connections with others.

--- a/src/content/releases/liminal-space.md
+++ b/src/content/releases/liminal-space.md
@@ -10,7 +10,6 @@ streamingLinks:
   bandcamp: "https://brylie.bandcamp.com/album/liminal-space"
   appleMusic: "https://music.apple.com/fi/album/liminal-space-ep/1694224333"
   spotify: "https://open.spotify.com/album/0DifRtnVDLsYzfqipMpjoW"
-downloadUrl: "https://freemusicarchive.org/music/Brylie_Christopher_Oxley/liminal-space"
 ---
 
 Created during a transition period, this EP explores themes of love, life, and relationships through jazz-infused electronic and synth pop soundscapes.

--- a/src/content/releases/liminal-space.md
+++ b/src/content/releases/liminal-space.md
@@ -1,0 +1,16 @@
+---
+title: "Liminal Space"
+description: "While going through a transition period, reflecting on love, life, and relationships"
+releaseDate: 2023-05-07
+releaseType: "ep"
+genre: ["jazz", "electronic", "synth pop"]
+license: "CC-BY-4.0"
+streamingLinks:
+  fma: "https://freemusicarchive.org/music/Brylie_Christopher_Oxley/liminal-space"
+  bandcamp: "https://brylie.bandcamp.com/album/liminal-space"
+  appleMusic: "https://music.apple.com/fi/album/liminal-space-ep/1694224333"
+  spotify: "https://open.spotify.com/album/0DifRtnVDLsYzfqipMpjoW"
+downloadUrl: "https://freemusicarchive.org/music/Brylie_Christopher_Oxley/liminal-space"
+---
+
+Created during a transition period, this EP explores themes of love, life, and relationships through jazz-infused electronic and synth pop soundscapes.

--- a/src/content/releases/murmurations.md
+++ b/src/content/releases/murmurations.md
@@ -1,7 +1,7 @@
 ---
 title: "Murmurations"
 description: "Collective movements in sound and harmony"
-releaseDate: 2024-05-01
+releaseDate: 2024-07-31
 releaseType: "album"
 genre: ["ambient", "electronic", "generative"]
 license: "CC-BY-4.0"

--- a/src/content/releases/murmurations.md
+++ b/src/content/releases/murmurations.md
@@ -7,6 +7,11 @@ genre: ["ambient", "electronic", "generative"]
 license: "CC-BY-4.0"
 streamingLinks:
   soundcloud: "https://soundcloud.com/brylie/sets/murmurations"
+  fma: "https://freemusicarchive.org/music/Brylie_Christopher_Oxley/murmurations"
+  bandcamp: "https://brylie.bandcamp.com/album/murmurations"
+  appleMusic: "https://music.apple.com/fi/album/murmurations/1760424222"
+  spotify: "https://open.spotify.com/album/4QhCY6CVzTSCYhbWQTEleA"
+downloadUrl: "https://freemusicarchive.org/music/Brylie_Christopher_Oxley/murmurations"
 ---
 
 Collective movements in sound and harmony, inspired by the synchronized flight patterns of birds, expressed through layered electronic textures and organic harmonies.

--- a/src/content/releases/murmurations.md
+++ b/src/content/releases/murmurations.md
@@ -1,0 +1,12 @@
+---
+title: "Murmurations"
+description: "Collective movements in sound and harmony"
+releaseDate: 2024-05-01
+releaseType: "album"
+genre: ["ambient", "electronic", "generative"]
+license: "CC-BY-4.0"
+streamingLinks:
+  soundcloud: "https://soundcloud.com/brylie/sets/murmurations"
+---
+
+Collective movements in sound and harmony, inspired by the synchronized flight patterns of birds, expressed through layered electronic textures and organic harmonies.

--- a/src/content/releases/murmurations.md
+++ b/src/content/releases/murmurations.md
@@ -11,7 +11,6 @@ streamingLinks:
   bandcamp: "https://brylie.bandcamp.com/album/murmurations"
   appleMusic: "https://music.apple.com/fi/album/murmurations/1760424222"
   spotify: "https://open.spotify.com/album/4QhCY6CVzTSCYhbWQTEleA"
-downloadUrl: "https://freemusicarchive.org/music/Brylie_Christopher_Oxley/murmurations"
 ---
 
 Collective movements in sound and harmony, inspired by the synchronized flight patterns of birds, expressed through layered electronic textures and organic harmonies.

--- a/src/content/releases/neither-and-both.md
+++ b/src/content/releases/neither-and-both.md
@@ -1,0 +1,12 @@
+---
+title: "Neither and Both"
+description: "Exploring duality through ambient soundscapes"
+releaseDate: 2023-10-01
+releaseType: "album"
+genre: ["ambient", "electronic", "experimental"]
+license: "CC-BY-4.0"
+streamingLinks:
+  soundcloud: "https://soundcloud.com/brylie/sets/neither-and-both"
+---
+
+Exploring duality through ambient soundscapes that exist between states, blending contrasts and embracing paradox through evolving sonic textures.

--- a/src/content/releases/neither-and-both.md
+++ b/src/content/releases/neither-and-both.md
@@ -1,12 +1,17 @@
 ---
 title: "Neither and Both"
 description: "Exploring duality through ambient soundscapes"
-releaseDate: 2023-10-01
+releaseDate: 2023-12-06
 releaseType: "album"
 genre: ["ambient", "electronic", "experimental"]
 license: "CC-BY-4.0"
 streamingLinks:
   soundcloud: "https://soundcloud.com/brylie/sets/neither-and-both"
+  fma: "https://freemusicarchive.org/music/Brylie_Christopher_Oxley/neither-and-both"
+  bandcamp: "https://brylie.bandcamp.com/album/neither-and-both"
+  appleMusic: "https://music.apple.com/fi/album/a-gentle-fog-descends/1720919764"
+  spotify: "https://open.spotify.com/album/0B4tC0NoxMk5ovqxwUxbc4"
+downloadUrl: "https://freemusicarchive.org/music/Brylie_Christopher_Oxley/neither-and-both"
 ---
 
 Exploring duality through ambient soundscapes that exist between states, blending contrasts and embracing paradox through evolving sonic textures.

--- a/src/content/releases/neither-and-both.md
+++ b/src/content/releases/neither-and-both.md
@@ -11,7 +11,6 @@ streamingLinks:
   bandcamp: "https://brylie.bandcamp.com/album/neither-and-both"
   appleMusic: "https://music.apple.com/fi/album/a-gentle-fog-descends/1720919764"
   spotify: "https://open.spotify.com/album/0B4tC0NoxMk5ovqxwUxbc4"
-downloadUrl: "https://freemusicarchive.org/music/Brylie_Christopher_Oxley/neither-and-both"
 ---
 
 Exploring duality through ambient soundscapes that exist between states, blending contrasts and embracing paradox through evolving sonic textures.

--- a/src/content/releases/new-beginnings.md
+++ b/src/content/releases/new-beginnings.md
@@ -7,9 +7,12 @@ genre: ["new age", "ambient", "electronic"]
 license: "CC-BY-4.0"
 streamingLinks:
   soundcloud: "https://soundcloud.com/brylie/sets/new-beginnings"
+  fma: "https://freemusicarchive.org/music/Brylie_Christopher_Oxley/new-beginnings"
+  bandcamp: "https://brylie.bandcamp.com/album/new-beginnings"
   appleMusic: "https://music.apple.com/fi/album/new-beginnings/1841347101"
   spotify: "https://open.spotify.com/album/59irjKb2iKUTPFWBMMs6hL"
   youtubeMusic: "https://music.youtube.com/playlist?list=OLAK5uy_m6hWOWtnhYmKoCke493hAafcmldaXU7zc"
+downloadUrl: "https://freemusicarchive.org/music/Brylie_Christopher_Oxley/new-beginnings"
 ---
 
 Going where the light leads.

--- a/src/content/releases/new-beginnings.md
+++ b/src/content/releases/new-beginnings.md
@@ -12,7 +12,6 @@ streamingLinks:
   appleMusic: "https://music.apple.com/fi/album/new-beginnings/1841347101"
   spotify: "https://open.spotify.com/album/59irjKb2iKUTPFWBMMs6hL"
   youtubeMusic: "https://music.youtube.com/playlist?list=OLAK5uy_m6hWOWtnhYmKoCke493hAafcmldaXU7zc"
-downloadUrl: "https://freemusicarchive.org/music/Brylie_Christopher_Oxley/new-beginnings"
 ---
 
 Going where the light leads.

--- a/src/content/releases/new-beginnings.md
+++ b/src/content/releases/new-beginnings.md
@@ -1,0 +1,15 @@
+---
+title: "New Beginnings"
+description: "Going where the light leads"
+releaseDate: 2025-09-18
+releaseType: "album"
+genre: ["new age", "ambient", "electronic"]
+license: "CC-BY-4.0"
+streamingLinks:
+  soundcloud: "https://soundcloud.com/brylie/sets/new-beginnings"
+  appleMusic: "https://music.apple.com/fi/album/new-beginnings/1841347101"
+  spotify: "https://open.spotify.com/album/59irjKb2iKUTPFWBMMs6hL"
+  youtubeMusic: "https://music.youtube.com/playlist?list=OLAK5uy_m6hWOWtnhYmKoCke493hAafcmldaXU7zc"
+---
+
+Going where the light leads.

--- a/src/content/releases/rational-limits.md
+++ b/src/content/releases/rational-limits.md
@@ -10,7 +10,6 @@ streamingLinks:
   bandcamp: "https://brylie.bandcamp.com/album/rational-limits"
   appleMusic: "https://music.apple.com/fi/album/rational-limits-single/1666678621"
   spotify: "https://open.spotify.com/album/7LKyABBYOyyW13lR8XkysZ"
-downloadUrl: "https://freemusicarchive.org/music/Brylie_Christopher_Oxley/rational-limits-1"
 ---
 
 Ambient, electronic composition blending beats, piano, and choir elements with experimental and minimalist influences.

--- a/src/content/releases/rational-limits.md
+++ b/src/content/releases/rational-limits.md
@@ -1,0 +1,16 @@
+---
+title: "Rational Limits"
+description: "Ambient, electronic with blended beats, piano, and choir"
+releaseDate: 2022-12-31
+releaseType: "single"
+genre: ["ambient", "electronic", "IDM", "experimental", "minimalism"]
+license: "CC-BY-4.0"
+streamingLinks:
+  fma: "https://freemusicarchive.org/music/Brylie_Christopher_Oxley/rational-limits-1"
+  bandcamp: "https://brylie.bandcamp.com/album/rational-limits"
+  appleMusic: "https://music.apple.com/fi/album/rational-limits-single/1666678621"
+  spotify: "https://open.spotify.com/album/7LKyABBYOyyW13lR8XkysZ"
+downloadUrl: "https://freemusicarchive.org/music/Brylie_Christopher_Oxley/rational-limits-1"
+---
+
+Ambient, electronic composition blending beats, piano, and choir elements with experimental and minimalist influences.

--- a/src/content/releases/renewed-energy.md
+++ b/src/content/releases/renewed-energy.md
@@ -1,0 +1,17 @@
+---
+title: "Renewed Energy"
+description: "Inspired by sources from sunshine to centering prayer that breathe life into our being"
+releaseDate: 2023-10-22
+releaseType: "album"
+genre: ["electronic", "ambient", "experimental"]
+license: "CC-BY-4.0"
+streamingLinks:
+  soundcloud: "https://soundcloud.com/brylie/sets/renewed-energy"
+  fma: "https://freemusicarchive.org/music/Brylie_Christopher_Oxley/renewed-energy"
+  bandcamp: "https://brylie.bandcamp.com/album/renewed-energy"
+  appleMusic: "https://music.apple.com/fi/album/renewed-energy/1715833322"
+  spotify: "https://open.spotify.com/album/5ZFnigyZigvyH2W2jBFxDu"
+downloadUrl: "https://freemusicarchive.org/music/Brylie_Christopher_Oxley/renewed-energy"
+---
+
+Inspired by sources from sunshine to centering prayer that breathe life into our being.

--- a/src/content/releases/renewed-energy.md
+++ b/src/content/releases/renewed-energy.md
@@ -11,7 +11,6 @@ streamingLinks:
   bandcamp: "https://brylie.bandcamp.com/album/renewed-energy"
   appleMusic: "https://music.apple.com/fi/album/renewed-energy/1715833322"
   spotify: "https://open.spotify.com/album/5ZFnigyZigvyH2W2jBFxDu"
-downloadUrl: "https://freemusicarchive.org/music/Brylie_Christopher_Oxley/renewed-energy"
 ---
 
 Inspired by sources from sunshine to centering prayer that breathe life into our being.

--- a/src/content/releases/sojourn.md
+++ b/src/content/releases/sojourn.md
@@ -7,9 +7,12 @@ genre: ["ambient", "electronic", "experimental"]
 license: "CC-BY-4.0"
 streamingLinks:
   soundcloud: "https://soundcloud.com/brylie/sets/sojourn"
+  fma: "https://freemusicarchive.org/music/Brylie_Christopher_Oxley/sojourn"
+  bandcamp: "https://brylie.bandcamp.com/album/sojourn"
   appleMusic: "https://music.apple.com/fi/album/sojourn-ep/1865487998"
   spotify: "https://open.spotify.com/album/5mpSyCDu0eckN49060b67C"
   youtubeMusic: "https://music.youtube.com/playlist?list=OLAK5uy_lZsUkLJT3HB3G1hxWLLQEko2Ljb13_7Lg"
+downloadUrl: "https://freemusicarchive.org/music/Brylie_Christopher_Oxley/sojourn"
 ---
 
 Meditations in transition.

--- a/src/content/releases/sojourn.md
+++ b/src/content/releases/sojourn.md
@@ -12,7 +12,6 @@ streamingLinks:
   appleMusic: "https://music.apple.com/fi/album/sojourn-ep/1865487998"
   spotify: "https://open.spotify.com/album/5mpSyCDu0eckN49060b67C"
   youtubeMusic: "https://music.youtube.com/playlist?list=OLAK5uy_lZsUkLJT3HB3G1hxWLLQEko2Ljb13_7Lg"
-downloadUrl: "https://freemusicarchive.org/music/Brylie_Christopher_Oxley/sojourn"
 ---
 
 Meditations in transition.

--- a/src/content/releases/sojourn.md
+++ b/src/content/releases/sojourn.md
@@ -1,0 +1,15 @@
+---
+title: "Sojourn"
+description: "Meditations in transition"
+releaseDate: 2025-12-31
+releaseType: "ep"
+genre: ["ambient", "electronic", "experimental"]
+license: "CC-BY-4.0"
+streamingLinks:
+  soundcloud: "https://soundcloud.com/brylie/sets/sojourn"
+  appleMusic: "https://music.apple.com/fi/album/sojourn-ep/1865487998"
+  spotify: "https://open.spotify.com/album/5mpSyCDu0eckN49060b67C"
+  youtubeMusic: "https://music.youtube.com/playlist?list=OLAK5uy_lZsUkLJT3HB3G1hxWLLQEko2Ljb13_7Lg"
+---
+
+Meditations in transition.

--- a/src/content/releases/solo.md
+++ b/src/content/releases/solo.md
@@ -1,12 +1,17 @@
 ---
 title: "Solo"
 description: "Latest album showcasing refined piano impressionism"
-releaseDate: 2025-01-01
+releaseDate: 2025-05-01
 releaseType: "album"
 genre: ["piano", "impressionism", "contemporary classical"]
 license: "CC-BY-4.0"
 streamingLinks:
   soundcloud: "https://soundcloud.com/brylie/sets/solo"
+  fma: "https://freemusicarchive.org/music/Brylie_Christopher_Oxley/solo"
+  bandcamp: "https://brylie.bandcamp.com/album/solo"
+  appleMusic: "https://music.apple.com/fi/album/solo/1819288691"
+  spotify: "https://open.spotify.com/album/04UHRUCtmvoSAnDNBucEWw"
+downloadUrl: "https://freemusicarchive.org/music/Brylie_Christopher_Oxley/solo"
 ---
 
 Latest album showcasing refined piano impressionism, featuring delicate compositions that explore introspective themes through minimalist piano techniques.

--- a/src/content/releases/solo.md
+++ b/src/content/releases/solo.md
@@ -1,0 +1,12 @@
+---
+title: "Solo"
+description: "Latest album showcasing refined piano impressionism"
+releaseDate: 2025-01-01
+releaseType: "album"
+genre: ["piano", "impressionism", "contemporary classical"]
+license: "CC-BY-4.0"
+streamingLinks:
+  soundcloud: "https://soundcloud.com/brylie/sets/solo"
+---
+
+Latest album showcasing refined piano impressionism, featuring delicate compositions that explore introspective themes through minimalist piano techniques.

--- a/src/content/releases/solo.md
+++ b/src/content/releases/solo.md
@@ -11,7 +11,6 @@ streamingLinks:
   bandcamp: "https://brylie.bandcamp.com/album/solo"
   appleMusic: "https://music.apple.com/fi/album/solo/1819288691"
   spotify: "https://open.spotify.com/album/04UHRUCtmvoSAnDNBucEWw"
-downloadUrl: "https://freemusicarchive.org/music/Brylie_Christopher_Oxley/solo"
 ---
 
 Latest album showcasing refined piano impressionism, featuring delicate compositions that explore introspective themes through minimalist piano techniques.

--- a/src/content/releases/tides-of-change.md
+++ b/src/content/releases/tides-of-change.md
@@ -1,12 +1,17 @@
 ---
 title: "Tides of Change"
 description: "Flowing compositions capturing transformation"
-releaseDate: 2024-08-01
+releaseDate: 2024-11-17
 releaseType: "album"
 genre: ["ambient", "electronic", "experimental"]
 license: "CC-BY-4.0"
 streamingLinks:
   soundcloud: "https://soundcloud.com/brylie/sets/tides-of-change"
+  fma: "https://freemusicarchive.org/music/Brylie_Christopher_Oxley/tides-of-change"
+  bandcamp: "https://brylie.bandcamp.com/album/tides-of-change"
+  appleMusic: "https://music.apple.com/fi/album/tides-of-change/1780792747"
+  spotify: "https://open.spotify.com/album/5rRUEdD8jbUlzjLyEx3Lsk"
+downloadUrl: "https://freemusicarchive.org/music/Brylie_Christopher_Oxley/tides-of-change"
 ---
 
 Flowing compositions capturing transformation through evolving soundscapes and rhythmic patterns that mirror the ebb and flow of change.

--- a/src/content/releases/tides-of-change.md
+++ b/src/content/releases/tides-of-change.md
@@ -11,7 +11,6 @@ streamingLinks:
   bandcamp: "https://brylie.bandcamp.com/album/tides-of-change"
   appleMusic: "https://music.apple.com/fi/album/tides-of-change/1780792747"
   spotify: "https://open.spotify.com/album/5rRUEdD8jbUlzjLyEx3Lsk"
-downloadUrl: "https://freemusicarchive.org/music/Brylie_Christopher_Oxley/tides-of-change"
 ---
 
 Flowing compositions capturing transformation through evolving soundscapes and rhythmic patterns that mirror the ebb and flow of change.

--- a/src/content/releases/tides-of-change.md
+++ b/src/content/releases/tides-of-change.md
@@ -1,0 +1,12 @@
+---
+title: "Tides of Change"
+description: "Flowing compositions capturing transformation"
+releaseDate: 2024-08-01
+releaseType: "album"
+genre: ["ambient", "electronic", "experimental"]
+license: "CC-BY-4.0"
+streamingLinks:
+  soundcloud: "https://soundcloud.com/brylie/sets/tides-of-change"
+---
+
+Flowing compositions capturing transformation through evolving soundscapes and rhythmic patterns that mirror the ebb and flow of change.

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -48,6 +48,11 @@ const personSchema = {
     "https://soundcloud.com/brylie",
     "https://brylie.bandcamp.com",
     "https://freemusicarchive.org/music/Brylie_Christopher_Oxley",
+    "https://bsky.app/profile/brylie.bsky.social",
+    "https://music.apple.com/fi/artist/brylie-christopher/1841347105",
+    "https://open.spotify.com/artist/5QEaapYiiiIH65gfhBgsv7",
+    "https://www.youtube.com/@brylie_music",
+    "https://www.twitch.tv/brylie_music",
   ],
 };
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -53,6 +53,7 @@ const personSchema = {
     "https://open.spotify.com/artist/5QEaapYiiiIH65gfhBgsv7",
     "https://www.youtube.com/@brylie_music",
     "https://www.twitch.tv/brylie_music",
+    "https://www.instagram.com/brylie.music",
   ],
 };
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -11,71 +11,181 @@ const releases = (await getCollection("releases")).sort(
 
 // Get the 6 most recent releases for the homepage
 const recentReleases = releases.slice(0, 6);
+
+// Generate comprehensive schema.org structured data
+const personSchema = {
+  "@context": "https://schema.org",
+  "@type": "MusicGroup",
+  name: "Brylie Christopher",
+  description:
+    "Finland-based musician creating abstract electronic minimalism and mixed instrumental compositions",
+  url: Astro.url.href,
+  genre: [
+    "Electronic",
+    "Ambient",
+    "Experimental",
+    "IDM",
+    "Minimalism",
+    "Piano",
+  ],
+  foundingLocation: {
+    "@type": "Place",
+    address: {
+      "@type": "PostalAddress",
+      addressCountry: "FI",
+    },
+  },
+  album: recentReleases.map((release) => ({
+    "@type": "MusicAlbum",
+    name: release.data.title,
+    datePublished: release.data.releaseDate.toISOString().split("T")[0],
+    url: new URL(
+      `/releases/${release.data.urlSlug || release.id}/`,
+      Astro.site || Astro.url.origin
+    ).href,
+  })),
+  sameAs: [
+    "https://soundcloud.com/brylie",
+    "https://brylie.bandcamp.com",
+    "https://freemusicarchive.org/music/Brylie_Christopher_Oxley",
+  ],
+};
+
+const websiteSchema = {
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  name: SITE_TITLE,
+  description:
+    "Finland-based musician creating abstract electronic minimalism and mixed instrumental compositions. All works released under Creative Commons licensing.",
+  url: Astro.url.href,
+  author: {
+    "@type": "MusicGroup",
+    name: "Brylie Christopher",
+  },
+  potentialAction: {
+    "@type": "SearchAction",
+    target: {
+      "@type": "EntryPoint",
+      urlTemplate:
+        new URL("/releases/", Astro.site || Astro.url.origin).href +
+        "?q={search_term_string}",
+    },
+    "query-input": "required name=search_term_string",
+  },
+};
 ---
 
 <Layout title={SITE_TITLE} description={SITE_DESCRIPTION}>
+  <script type="application/ld+json" set:html={JSON.stringify(personSchema)} />
+  <script type="application/ld+json" set:html={JSON.stringify(websiteSchema)} />
+
   <div class="max-w-4xl mx-auto px-4 py-12">
-    <div class="text-center mb-16">
-      <h1 class="text-4xl md:text-6xl font-bold text-white mb-6">
+    <header
+      class="text-center mb-16"
+      itemscope
+      itemtype="https://schema.org/MusicGroup"
+    >
+      <h1
+        class="text-4xl md:text-6xl font-bold text-white mb-6"
+        itemprop="name"
+      >
         🎵 Brylie Christopher
       </h1>
-      <p class="text-xl text-gray-300 max-w-3xl mx-auto leading-relaxed">
+      <p
+        class="text-xl text-gray-300 max-w-3xl mx-auto leading-relaxed"
+        itemprop="description"
+      >
         Finland-based musician creating abstract electronic minimalism and mixed
         instrumental compositions. All works released under Creative Commons
         licensing.
       </p>
-    </div>
+      <meta itemprop="genre" content="Electronic" />
+      <meta itemprop="genre" content="Ambient" />
+      <meta itemprop="genre" content="Experimental" />
+      <link itemprop="url" href={Astro.url.href} />
+    </header>
 
     <div class="bg-gray-900 rounded-lg shadow-xl p-8 mb-8">
-      <p class="text-lg text-gray-200 mb-8 leading-relaxed">
-        Brylie Christopher's creative output spans a wide spectrum of electronic
-        and instrumental music, marked by atmospheric pieces that weave together
-        diverse instruments, timbres, and textures. His genre-blending
-        compositions are used for wellness, film, podcasts, and video games,
-        with works featured in independent documentaries.
-      </p>
-
-      <h2 class="text-3xl font-semibold text-white mb-6">Recent Discography</h2>
-      <div class="grid md:grid-cols-2 gap-6 mb-8">
-        {recentReleases.map((release) => <ReleaseCard release={release} />)}
+      <div
+        itemprop="about"
+        itemscope
+        itemtype="https://schema.org/CreativeWork"
+      >
+        <p
+          class="text-lg text-gray-200 mb-8 leading-relaxed"
+          itemprop="description"
+        >
+          Brylie Christopher's creative output spans a wide spectrum of
+          electronic and instrumental music, marked by atmospheric pieces that
+          weave together diverse instruments, timbres, and textures. His
+          genre-blending compositions are used for wellness, film, podcasts, and
+          video games, with works featured in independent documentaries.
+        </p>
       </div>
 
-      <div class="bg-gray-800 rounded-lg p-6">
-        <h3 class="text-xl font-semibold text-white mb-4">🎨 Musical Style</h3>
-        <ul class="space-y-2 text-gray-200">
+      <section aria-labelledby="recent-releases">
+        <h2 id="recent-releases" class="text-3xl font-semibold text-white mb-6">
+          Recent Discography
+        </h2>
+        <div class="grid md:grid-cols-2 gap-6 mb-8">
+          {recentReleases.map((release) => <ReleaseCard release={release} />)}
+        </div>
+        <div class="text-center">
+          <a
+            href="/releases/"
+            class="inline-block bg-blue-600 hover:bg-blue-500 text-white font-semibold px-6 py-3 rounded-lg transition-colors"
+          >
+            View All Releases
+          </a>
+        </div>
+      </section>
+
+      <section
+        class="bg-gray-800 rounded-lg p-6 mt-8"
+        aria-labelledby="musical-style"
+      >
+        <h3 id="musical-style" class="text-xl font-semibold text-white mb-4">
+          🎨 Musical Style
+        </h3>
+        <ul class="space-y-2 text-gray-200" role="list">
           <li class="flex items-start">
-            <span class="text-blue-400 mr-3">•</span>
-            Abstract electronic minimalism
+            <span class="text-blue-400 mr-3" aria-hidden="true">•</span>
+            <span>Abstract electronic minimalism</span>
           </li>
           <li class="flex items-start">
-            <span class="text-blue-400 mr-3">•</span>
-            Mixed instrumental compositions
+            <span class="text-blue-400 mr-3" aria-hidden="true">•</span>
+            <span>Mixed instrumental compositions</span>
           </li>
           <li class="flex items-start">
-            <span class="text-blue-400 mr-3">•</span>
-            Genre-blending atmospheric pieces
+            <span class="text-blue-400 mr-3" aria-hidden="true">•</span>
+            <span>Genre-blending atmospheric pieces</span>
           </li>
           <li class="flex items-start">
-            <span class="text-blue-400 mr-3">•</span>
-            Diverse instruments, timbres, and textures
+            <span class="text-blue-400 mr-3" aria-hidden="true">•</span>
+            <span>Diverse instruments, timbres, and textures</span>
           </li>
         </ul>
-      </div>
+      </section>
     </div>
 
-    <div class="text-center">
+    <section class="text-center" aria-labelledby="licensing-info">
       <div class="bg-gray-900 rounded-lg p-6 mb-6">
-        <p class="text-lg text-blue-300 mb-2">🆓 Creative Commons Licensed</p>
+        <h2 id="licensing-info" class="text-lg text-blue-300 mb-2">
+          🆓 Creative Commons Licensed
+        </h2>
         <p class="text-gray-300">
           All of Brylie's music is released under Creative Commons licensing,
           making it freely available for creative projects, wellness
           applications, and media productions.
         </p>
       </div>
-      <p class="text-gray-400">
-        Music for wellness • Film scoring • Podcast soundtracks • Video game
-        atmospheres • Independent documentaries
-      </p>
-    </div>
+      <div itemscope itemtype="https://schema.org/Organization">
+        <meta itemprop="name" content="Brylie Christopher Music" />
+        <p class="text-gray-400" itemprop="description">
+          Music for wellness • Film scoring • Podcast soundtracks • Video game
+          atmospheres • Independent documentaries
+        </p>
+      </div>
+    </section>
   </div>
 </Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,16 @@
 ---
 import Layout from "../layouts/Layout.astro";
 import { SITE_DESCRIPTION, SITE_TITLE } from "../consts";
+import { getCollection } from "astro:content";
+import ReleaseCard from "../components/ReleaseCard.astro";
+
+// Fetch and sort releases by date (newest first)
+const releases = (await getCollection("releases")).sort(
+  (a, b) => b.data.releaseDate.valueOf() - a.data.releaseDate.valueOf()
+);
+
+// Get the 6 most recent releases for the homepage
+const recentReleases = releases.slice(0, 6);
 ---
 
 <Layout title={SITE_TITLE} description={SITE_DESCRIPTION}>
@@ -27,78 +37,7 @@ import { SITE_DESCRIPTION, SITE_TITLE } from "../consts";
 
       <h2 class="text-3xl font-semibold text-white mb-6">Recent Discography</h2>
       <div class="grid md:grid-cols-2 gap-6 mb-8">
-        <div class="bg-gray-800 rounded-lg p-6">
-          <h3 class="text-xl font-semibold text-blue-300 mb-2">
-            <a
-              href="https://soundcloud.com/brylie/sets/solo"
-              class="hover:text-blue-200 transition-colors"
-              target="_blank"
-              rel="noopener noreferrer">Solo</a
-            >
-          </h3>
-          <p class="text-gray-400 text-sm mb-3">2025</p>
-          <p class="text-gray-200">
-            Latest album showcasing refined piano impressionism
-          </p>
-        </div>
-
-        <div class="bg-gray-800 rounded-lg p-6">
-          <h3 class="text-xl font-semibold text-blue-300 mb-2">
-            <a
-              href="https://soundcloud.com/brylie/sets/tides-of-change"
-              class="hover:text-blue-200 transition-colors"
-              target="_blank"
-              rel="noopener noreferrer">Tides of Change</a
-            >
-          </h3>
-          <p class="text-gray-400 text-sm mb-3">2024</p>
-          <p class="text-gray-200">
-            Flowing compositions capturing transformation
-          </p>
-        </div>
-
-        <div class="bg-gray-800 rounded-lg p-6">
-          <h3 class="text-xl font-semibold text-blue-300 mb-2">
-            <a
-              href="https://soundcloud.com/brylie/sets/murmurations"
-              class="hover:text-blue-200 transition-colors"
-              target="_blank"
-              rel="noopener noreferrer">Murmurations</a
-            >
-          </h3>
-          <p class="text-gray-400 text-sm mb-3">2024</p>
-          <p class="text-gray-200">Collective movements in sound and harmony</p>
-        </div>
-
-        <div class="bg-gray-800 rounded-lg p-6">
-          <h3 class="text-xl font-semibold text-blue-300 mb-2">
-            <a
-              href="https://soundcloud.com/brylie/sets/epicycles"
-              class="hover:text-blue-200 transition-colors"
-              target="_blank"
-              rel="noopener noreferrer">Epicycles</a
-            >
-          </h3>
-          <p class="text-gray-400 text-sm mb-3">2024</p>
-          <p class="text-gray-200">
-            Cyclical patterns and recurring musical themes
-          </p>
-        </div>
-
-        <div class="bg-gray-800 rounded-lg p-6 md:col-span-2">
-          <h3 class="text-xl font-semibold text-blue-300 mb-2">
-            <a
-              href="https://soundcloud.com/brylie/sets/neither-and-both"
-              class="hover:text-blue-200 transition-colors"
-              target="_blank"
-              rel="noopener noreferrer">Neither and Both</a
-            >
-          </h3>
-          <p class="text-gray-400 text-sm mb-3">2023</p>
-          <p class="text-gray-200">
-            Exploring duality through ambient soundscapes
-          </p>
-        </div>
+        {recentReleases.map((release) => <ReleaseCard release={release} />)}
       </div>
 
       <div class="bg-gray-800 rounded-lg p-6">

--- a/src/pages/releases/[...slug].astro
+++ b/src/pages/releases/[...slug].astro
@@ -31,25 +31,66 @@ const platforms = [
   { key: "youtube", icon: "mdi:youtube", label: "YouTube Music" },
 ] as const;
 
-// Generate comprehensive schema.org MusicAlbum JSON-LD
-const schemaOrg = {
+// Generate SEO schemas
+const slug = data.urlSlug || release.id;
+const licenseUrl =
+  data.licenseUrl ||
+  `https://creativecommons.org/licenses/${data.license.toLowerCase().replace("cc-", "").replace(/^by/, "by").replace("-", "/")}/`;
+
+const breadcrumbSchema = {
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  itemListElement: [
+    {
+      "@type": "ListItem",
+      position: 1,
+      name: "Home",
+      item: new URL("/", Astro.site || Astro.url.origin).href,
+    },
+    {
+      "@type": "ListItem",
+      position: 2,
+      name: "Releases",
+      item: new URL("/releases/", Astro.site || Astro.url.origin).href,
+    },
+    {
+      "@type": "ListItem",
+      position: 3,
+      name: data.title,
+      item: Astro.url.href,
+    },
+  ],
+};
+
+const albumSchema = {
   "@context": "https://schema.org",
   "@type": "MusicAlbum",
   name: data.title,
   description: data.description,
   byArtist: {
-    "@type": "Person",
+    "@type": "MusicGroup",
     name: data.artist || "Brylie Christopher",
+    url: new URL("/", Astro.site || Astro.url.origin).href,
   },
   datePublished: data.releaseDate.toISOString().split("T")[0],
   albumReleaseType: `https://schema.org/${data.releaseType.charAt(0).toUpperCase() + data.releaseType.slice(1)}Release`,
   genre: data.genre,
-  license:
-    data.licenseUrl ||
-    `https://creativecommons.org/licenses/${data.license.toLowerCase().replace("cc-", "").replace("-", "/")}/`,
+  license: licenseUrl,
   url: Astro.url.href,
-  image: data.coverImage?.src,
+  image: data.coverImage?.src
+    ? new URL(data.coverImage.src, Astro.site || Astro.url.origin).href
+    : undefined,
   inLanguage: "en",
+  breadcrumb: breadcrumbSchema,
+  ...(data.downloadUrl && {
+    offers: {
+      "@type": "Offer",
+      availability: "https://schema.org/InStock",
+      price: "0",
+      priceCurrency: "USD",
+      url: data.downloadUrl,
+    },
+  }),
   ...(data.tracks && {
     track: data.tracks.map((track, index) => ({
       "@type": "MusicRecording",
@@ -57,9 +98,11 @@ const schemaOrg = {
       name: track.title,
       duration: track.duration,
       byArtist: {
-        "@type": "Person",
+        "@type": "MusicGroup",
         name: data.artist || "Brylie Christopher",
       },
+      license: licenseUrl,
+      inLanguage: "en",
     })),
     numTracks: data.tracks.length,
   }),
@@ -81,22 +124,56 @@ const pageDescription = data.description;
   description={pageDescription}
   image={data.ogImage || data.coverImage}
 >
-  <script type="application/ld+json" set:html={JSON.stringify(schemaOrg)} />
+  <script type="application/ld+json" set:html={JSON.stringify(albumSchema)} />
 
   <div class="max-w-4xl mx-auto px-4 py-12">
-    <nav class="mb-8" aria-label="Breadcrumb">
+    <nav
+      class="mb-8"
+      aria-label="Breadcrumb"
+      itemscope
+      itemtype="https://schema.org/BreadcrumbList"
+    >
       <ol class="flex items-center gap-2 text-sm text-gray-400">
-        <li>
-          <a href="/" class="hover:text-blue-300 transition-colors">Home</a>
-        </li>
-        <li aria-hidden="true">/</li>
-        <li>
-          <a href="/releases/" class="hover:text-blue-300 transition-colors"
-            >Releases</a
+        <li
+          itemprop="itemListElement"
+          itemscope
+          itemtype="https://schema.org/ListItem"
+        >
+          <a
+            href="/"
+            class="hover:text-blue-300 transition-colors"
+            itemprop="item"
           >
+            <span itemprop="name">Home</span>
+          </a>
+          <meta itemprop="position" content="1" />
         </li>
         <li aria-hidden="true">/</li>
-        <li class="text-gray-300" aria-current="page">{data.title}</li>
+        <li
+          itemprop="itemListElement"
+          itemscope
+          itemtype="https://schema.org/ListItem"
+        >
+          <a
+            href="/releases/"
+            class="hover:text-blue-300 transition-colors"
+            itemprop="item"
+          >
+            <span itemprop="name">Releases</span>
+          </a>
+          <meta itemprop="position" content="2" />
+        </li>
+        <li aria-hidden="true">/</li>
+        <li
+          itemprop="itemListElement"
+          itemscope
+          itemtype="https://schema.org/ListItem"
+          class="text-gray-300"
+          aria-current="page"
+        >
+          <span itemprop="name">{data.title}</span>
+          <meta itemprop="position" content="3" />
+        </li>
       </ol>
     </nav>
 
@@ -137,7 +214,7 @@ const pageDescription = data.description;
                   <span
                     itemprop="byArtist"
                     itemscope
-                    itemtype="https://schema.org/Person"
+                    itemtype="https://schema.org/MusicGroup"
                   >
                     <span itemprop="name">{data.artist}</span>
                   </span>
@@ -319,6 +396,8 @@ const pageDescription = data.description;
       }
 
       <meta itemprop="datePublished" content={data.releaseDate.toISOString()} />
+      <link itemprop="license" href={licenseUrl} />
+      {data.downloadUrl && <link itemprop="offers" href={data.downloadUrl} />}
     </article>
 
     <div class="mt-8 text-center">

--- a/src/pages/releases/[...slug].astro
+++ b/src/pages/releases/[...slug].astro
@@ -1,0 +1,334 @@
+---
+import { getCollection } from "astro:content";
+import Layout from "../../layouts/Layout.astro";
+import FormattedDate from "../../components/FormattedDate.astro";
+import LicenseBadge from "../../components/LicenseBadge.astro";
+import { Icon } from "astro-icon/components";
+import { YouTube } from "@astro-community/astro-embed-youtube";
+import MarkdownIt from "markdown-it";
+
+const parser = new MarkdownIt();
+
+export async function getStaticPaths() {
+  const releases = await getCollection("releases");
+  return releases.map((release) => ({
+    params: { slug: release.data.urlSlug || release.id },
+    props: { release },
+  }));
+}
+
+const { release } = Astro.props;
+const { data, body } = release;
+const renderedContent = parser.render(body || "");
+
+// Platform icons mapping (alphabetically ordered)
+const platforms = [
+  { key: "appleMusic", icon: "mdi:apple", label: "Apple Music" },
+  { key: "bandcamp", icon: "mdi:bandcamp", label: "Bandcamp" },
+  { key: "fma", icon: "mdi:music-circle", label: "Free Music Archive" },
+  { key: "soundcloud", icon: "mdi:soundcloud", label: "SoundCloud" },
+  { key: "spotify", icon: "mdi:spotify", label: "Spotify" },
+  { key: "youtube", icon: "mdi:youtube", label: "YouTube Music" },
+] as const;
+
+// Generate comprehensive schema.org MusicAlbum JSON-LD
+const schemaOrg = {
+  "@context": "https://schema.org",
+  "@type": "MusicAlbum",
+  name: data.title,
+  description: data.description,
+  byArtist: {
+    "@type": "Person",
+    name: data.artist || "Brylie Christopher",
+  },
+  datePublished: data.releaseDate.toISOString().split("T")[0],
+  albumReleaseType: `https://schema.org/${data.releaseType.charAt(0).toUpperCase() + data.releaseType.slice(1)}Release`,
+  genre: data.genre,
+  license:
+    data.licenseUrl ||
+    `https://creativecommons.org/licenses/${data.license.toLowerCase().replace("cc-", "").replace("-", "/")}/`,
+  url: Astro.url.href,
+  image: data.coverImage?.src,
+  inLanguage: "en",
+  ...(data.tracks && {
+    track: data.tracks.map((track, index) => ({
+      "@type": "MusicRecording",
+      position: index + 1,
+      name: track.title,
+      duration: track.duration,
+      byArtist: {
+        "@type": "Person",
+        name: data.artist || "Brylie Christopher",
+      },
+    })),
+    numTracks: data.tracks.length,
+  }),
+  ...(data.recordLabel && {
+    recordLabel: {
+      "@type": "Organization",
+      name: data.recordLabel,
+    },
+  }),
+  ...(data.catalogNumber && { catalogNumber: data.catalogNumber }),
+};
+
+const pageTitle = `${data.title} - Music Release`;
+const pageDescription = data.description;
+---
+
+<Layout
+  title={pageTitle}
+  description={pageDescription}
+  image={data.ogImage || data.coverImage}
+>
+  <script type="application/ld+json" set:html={JSON.stringify(schemaOrg)} />
+
+  <div class="max-w-4xl mx-auto px-4 py-12">
+    <nav class="mb-8" aria-label="Breadcrumb">
+      <ol class="flex items-center gap-2 text-sm text-gray-400">
+        <li>
+          <a href="/" class="hover:text-blue-300 transition-colors">Home</a>
+        </li>
+        <li aria-hidden="true">/</li>
+        <li>
+          <a href="/releases/" class="hover:text-blue-300 transition-colors"
+            >Releases</a
+          >
+        </li>
+        <li aria-hidden="true">/</li>
+        <li class="text-gray-300" aria-current="page">{data.title}</li>
+      </ol>
+    </nav>
+
+    <article
+      class="bg-gray-900 rounded-lg shadow-xl p-8"
+      itemscope
+      itemtype="https://schema.org/MusicAlbum"
+    >
+      <header class="mb-8">
+        <h1
+          class="text-4xl md:text-5xl font-bold text-white mb-4"
+          itemprop="name"
+        >
+          {data.title}
+        </h1>
+
+        <div class="flex flex-wrap items-center gap-4 text-gray-300 mb-4">
+          <div class="flex items-center gap-2">
+            <Icon name="mdi:calendar" size={20} aria-hidden="true" />
+            <FormattedDate date={data.releaseDate} />
+          </div>
+
+          <span class="text-gray-600" aria-hidden="true">•</span>
+
+          <div class="flex items-center gap-2 capitalize">
+            <Icon name="mdi:album" size={20} aria-hidden="true" />
+            <span>{data.releaseType}</span>
+          </div>
+
+          {
+            data.artist && (
+              <>
+                <span class="text-gray-600" aria-hidden="true">
+                  •
+                </span>
+                <div class="flex items-center gap-2">
+                  <Icon name="mdi:account-music" size={20} aria-hidden="true" />
+                  <span
+                    itemprop="byArtist"
+                    itemscope
+                    itemtype="https://schema.org/Person"
+                  >
+                    <span itemprop="name">{data.artist}</span>
+                  </span>
+                </div>
+              </>
+            )
+          }
+        </div>
+
+        <div class="mb-6">
+          <LicenseBadge license={data.license} size={24} />
+        </div>
+
+        {
+          data.genre && data.genre.length > 0 && (
+            <div class="flex flex-wrap gap-2 mb-6">
+              {data.genre.map((genre) => (
+                <span
+                  class="bg-gray-800 text-blue-300 px-3 py-1 rounded-full text-sm"
+                  itemprop="genre"
+                >
+                  {genre}
+                </span>
+              ))}
+            </div>
+          )
+        }
+      </header>
+
+      {
+        data.coverImage && (
+          <div class="mb-8">
+            <img
+              src={data.coverImage.src}
+              alt={`${data.title} cover art`}
+              class="w-full max-w-lg mx-auto aspect-square object-cover rounded-lg shadow-lg"
+              itemprop="image"
+            />
+          </div>
+        )
+      }
+
+      <div
+        class="prose prose-invert prose-lg max-w-none mb-8"
+        itemprop="description"
+      >
+        <Fragment set:html={renderedContent} />
+      </div>
+
+      {
+        data.youtubeVideoId && (
+          <div class="mb-8">
+            <h2 class="text-2xl font-semibold text-white mb-4">Music Video</h2>
+            <div class="aspect-video rounded-lg overflow-hidden">
+              <YouTube id={data.youtubeVideoId} />
+            </div>
+          </div>
+        )
+      }
+
+      {
+        data.tracks && data.tracks.length > 0 && (
+          <div class="mb-8">
+            <h2 class="text-2xl font-semibold text-white mb-4">
+              Track Listing
+            </h2>
+            <div class="bg-gray-800 rounded-lg overflow-hidden">
+              <table class="w-full">
+                <thead class="bg-gray-700">
+                  <tr>
+                    <th class="px-4 py-3 text-left text-gray-300 font-semibold">
+                      #
+                    </th>
+                    <th class="px-4 py-3 text-left text-gray-300 font-semibold">
+                      Title
+                    </th>
+                    <th class="px-4 py-3 text-right text-gray-300 font-semibold">
+                      Duration
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {data.tracks.map((track, index) => (
+                    <tr
+                      class="border-t border-gray-700 hover:bg-gray-750 transition-colors"
+                      itemprop="track"
+                      itemscope
+                      itemtype="https://schema.org/MusicRecording"
+                    >
+                      <td class="px-4 py-3 text-gray-400">
+                        <span itemprop="position">{index + 1}</span>
+                      </td>
+                      <td class="px-4 py-3 text-gray-200" itemprop="name">
+                        {track.title}
+                      </td>
+                      <td
+                        class="px-4 py-3 text-right text-gray-400"
+                        itemprop="duration"
+                      >
+                        {track.duration}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )
+      }
+
+      {
+        data.collaborators && data.collaborators.length > 0 && (
+          <div class="mb-8">
+            <h2 class="text-2xl font-semibold text-white mb-4">
+              Collaborators
+            </h2>
+            <div class="flex flex-wrap gap-3">
+              {data.collaborators.map((collaborator) => (
+                <span class="bg-gray-800 text-gray-200 px-4 py-2 rounded-lg">
+                  {collaborator}
+                </span>
+              ))}
+            </div>
+          </div>
+        )
+      }
+
+      {
+        (data.recordLabel || data.catalogNumber) && (
+          <div class="mb-8 bg-gray-800 rounded-lg p-6">
+            <h2 class="text-xl font-semibold text-white mb-3">
+              Release Details
+            </h2>
+            <dl class="space-y-2">
+              {data.recordLabel && (
+                <div class="flex gap-3">
+                  <dt class="text-gray-400 font-medium">Label:</dt>
+                  <dd class="text-gray-200">{data.recordLabel}</dd>
+                </div>
+              )}
+              {data.catalogNumber && (
+                <div class="flex gap-3">
+                  <dt class="text-gray-400 font-medium">Catalog #:</dt>
+                  <dd class="text-gray-200">{data.catalogNumber}</dd>
+                </div>
+              )}
+            </dl>
+          </div>
+        )
+      }
+
+      {
+        data.streamingLinks && (
+          <div class="bg-gray-800 rounded-lg p-6">
+            <h2 class="text-2xl font-semibold text-white mb-4">
+              Listen & Purchase
+            </h2>
+            <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+              {platforms.map(({ key, icon, label }) => {
+                const url = data.streamingLinks?.[key];
+                if (!url) return null;
+
+                return (
+                  <a
+                    href={url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="flex items-center gap-3 bg-gray-700 hover:bg-gray-600 text-gray-200 hover:text-blue-300 px-4 py-3 rounded-lg transition-colors"
+                    aria-label={`Listen on ${label}`}
+                  >
+                    <Icon name={icon} size={28} aria-hidden="true" />
+                    <span class="font-medium">{label}</span>
+                  </a>
+                );
+              })}
+            </div>
+          </div>
+        )
+      }
+
+      <meta itemprop="datePublished" content={data.releaseDate.toISOString()} />
+    </article>
+
+    <div class="mt-8 text-center">
+      <a
+        href="/releases/"
+        class="inline-flex items-center gap-2 text-blue-300 hover:text-blue-200 transition-colors"
+      >
+        <Icon name="mdi:arrow-left" size={20} aria-hidden="true" />
+        <span>View All Releases</span>
+      </a>
+    </div>
+  </div>
+</Layout>

--- a/src/pages/releases/[...slug].astro
+++ b/src/pages/releases/[...slug].astro
@@ -4,7 +4,7 @@ import Layout from "../../layouts/Layout.astro";
 import FormattedDate from "../../components/FormattedDate.astro";
 import LicenseBadge from "../../components/LicenseBadge.astro";
 import { Icon } from "astro-icon/components";
-import { YouTube } from "@astro-community/astro-embed-youtube";
+import { YouTube } from "astro-embed";
 import MarkdownIt from "markdown-it";
 
 const parser = new MarkdownIt();

--- a/src/pages/releases/index.astro
+++ b/src/pages/releases/index.astro
@@ -12,15 +12,36 @@ const pageTitle = "Music Releases";
 const pageDescription =
   "Complete discography of music releases by Brylie Christopher, including albums, EPs, and singles. All works released under Creative Commons licensing.";
 
-// Generate schema.org ItemList for the collection
-const schemaOrg = {
+// Generate schema.org for SEO
+const breadcrumbSchema = {
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  itemListElement: [
+    {
+      "@type": "ListItem",
+      position: 1,
+      name: "Home",
+      item: new URL("/", Astro.site || Astro.url.origin).href,
+    },
+    {
+      "@type": "ListItem",
+      position: 2,
+      name: "Releases",
+      item: Astro.url.href,
+    },
+  ],
+};
+
+const collectionSchema = {
   "@context": "https://schema.org",
   "@type": "CollectionPage",
   name: pageTitle,
   description: pageDescription,
   url: Astro.url.href,
+  breadcrumb: breadcrumbSchema,
   mainEntity: {
     "@type": "ItemList",
+    numberOfItems: releases.length,
     itemListElement: releases.map((release, index) => ({
       "@type": "ListItem",
       position: index + 1,
@@ -29,7 +50,17 @@ const schemaOrg = {
         name: release.data.title,
         description: release.data.description,
         datePublished: release.data.releaseDate.toISOString().split("T")[0],
-        url: `/releases/${release.data.urlSlug || release.id}/`,
+        url: new URL(
+          `/releases/${release.data.urlSlug || release.id}/`,
+          Astro.site || Astro.url.origin
+        ).href,
+        genre: release.data.genre?.join(", "),
+        byArtist: {
+          "@type": "MusicGroup",
+          name: "Brylie Christopher",
+          url: new URL("/", Astro.site || Astro.url.origin).href,
+        },
+        license: release.data.license,
       },
     })),
   },
@@ -37,16 +68,44 @@ const schemaOrg = {
 ---
 
 <Layout title={pageTitle} description={pageDescription}>
-  <script type="application/ld+json" set:html={JSON.stringify(schemaOrg)} />
+  <script
+    type="application/ld+json"
+    set:html={JSON.stringify(collectionSchema)}
+  />
 
   <div class="max-w-6xl mx-auto px-4 py-12">
-    <nav class="mb-8" aria-label="Breadcrumb">
+    <nav
+      class="mb-8"
+      aria-label="Breadcrumb"
+      itemscope
+      itemtype="https://schema.org/BreadcrumbList"
+    >
       <ol class="flex items-center gap-2 text-sm text-gray-400">
-        <li>
-          <a href="/" class="hover:text-blue-300 transition-colors">Home</a>
+        <li
+          itemprop="itemListElement"
+          itemscope
+          itemtype="https://schema.org/ListItem"
+        >
+          <a
+            href="/"
+            class="hover:text-blue-300 transition-colors"
+            itemprop="item"
+          >
+            <span itemprop="name">Home</span>
+          </a>
+          <meta itemprop="position" content="1" />
         </li>
         <li aria-hidden="true">/</li>
-        <li class="text-gray-300" aria-current="page">Releases</li>
+        <li
+          itemprop="itemListElement"
+          itemscope
+          itemtype="https://schema.org/ListItem"
+          class="text-gray-300"
+          aria-current="page"
+        >
+          <span itemprop="name">Releases</span>
+          <meta itemprop="position" content="2" />
+        </li>
       </ol>
     </nav>
 

--- a/src/pages/releases/index.astro
+++ b/src/pages/releases/index.astro
@@ -1,0 +1,87 @@
+---
+import { getCollection } from "astro:content";
+import Layout from "../../layouts/Layout.astro";
+import ReleaseCard from "../../components/ReleaseCard.astro";
+
+// Fetch and sort releases by date (newest first)
+const releases = (await getCollection("releases")).sort(
+  (a, b) => b.data.releaseDate.valueOf() - a.data.releaseDate.valueOf()
+);
+
+const pageTitle = "Music Releases";
+const pageDescription =
+  "Complete discography of music releases by Brylie Christopher, including albums, EPs, and singles. All works released under Creative Commons licensing.";
+
+// Generate schema.org ItemList for the collection
+const schemaOrg = {
+  "@context": "https://schema.org",
+  "@type": "CollectionPage",
+  name: pageTitle,
+  description: pageDescription,
+  url: Astro.url.href,
+  mainEntity: {
+    "@type": "ItemList",
+    itemListElement: releases.map((release, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      item: {
+        "@type": "MusicAlbum",
+        name: release.data.title,
+        description: release.data.description,
+        datePublished: release.data.releaseDate.toISOString().split("T")[0],
+        url: `/releases/${release.data.urlSlug || release.id}/`,
+      },
+    })),
+  },
+};
+---
+
+<Layout title={pageTitle} description={pageDescription}>
+  <script type="application/ld+json" set:html={JSON.stringify(schemaOrg)} />
+
+  <div class="max-w-6xl mx-auto px-4 py-12">
+    <nav class="mb-8" aria-label="Breadcrumb">
+      <ol class="flex items-center gap-2 text-sm text-gray-400">
+        <li>
+          <a href="/" class="hover:text-blue-300 transition-colors">Home</a>
+        </li>
+        <li aria-hidden="true">/</li>
+        <li class="text-gray-300" aria-current="page">Releases</li>
+      </ol>
+    </nav>
+
+    <header class="text-center mb-12">
+      <h1 class="text-4xl md:text-5xl font-bold text-white mb-4">
+        Music Releases
+      </h1>
+      <p class="text-xl text-gray-300 max-w-3xl mx-auto">
+        Complete discography of albums, EPs, and singles. All works released
+        under Creative Commons licensing.
+      </p>
+    </header>
+
+    {
+      releases.length === 0 ? (
+        <div class="text-center py-12">
+          <p class="text-gray-400 text-lg">No releases found.</p>
+        </div>
+      ) : (
+        <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {releases.map((release) => (
+            <ReleaseCard release={release} />
+          ))}
+        </div>
+      )
+    }
+
+    <div class="mt-12 text-center">
+      <div class="bg-gray-900 rounded-lg p-6 inline-block">
+        <p class="text-lg text-blue-300 mb-2">🆓 Creative Commons Licensed</p>
+        <p class="text-gray-300">
+          All music is freely available for creative projects, wellness
+          applications, and media productions.
+        </p>
+      </div>
+    </div>
+  </div>
+</Layout>

--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -8,6 +8,78 @@ const parser = new MarkdownIt();
 
 export async function GET(context) {
 	const posts = await getCollection('blog');
+	const releases = await getCollection('releases');
+
+	// Combine blog posts and releases into a single feed
+	const blogItems = posts.map((post) => ({
+		...post.data,
+		link: `/blog/${post.id}/`,
+		content: sanitizeHtml(parser.render(post.body), {
+			allowedTags: sanitizeHtml.defaults.allowedTags.concat([ 'img' ]),
+			allowedAttributes: {
+				...sanitizeHtml.defaults.allowedAttributes,
+				img: [ 'src', 'alt', 'title', 'width', 'height' ],
+				a: [ 'href', 'title', 'target', 'rel' ],
+			},
+		}),
+	}));
+
+	const releaseItems = releases.map((release) => {
+		const slug = release.data.urlSlug || release.id;
+		const licenseInfo = release.data.license
+			? `<p><strong>License:</strong> <a href="https://creativecommons.org/licenses/${release.data.license.toLowerCase().replace('cc-', '').replace('-', '/')}/" target="_blank">${release.data.license}</a></p>`
+			: '';
+
+		// Build streaming links HTML
+		const streamingLinks = release.data.streamingLinks
+			? `<p><strong>Listen on:</strong> ${Object.entries(release.data.streamingLinks)
+				.filter(([ _, url ]) => url)
+				.map(([ platform, url ]) => {
+					const platformLabels = {
+						appleMusic: 'Apple Music',
+						bandcamp: 'Bandcamp',
+						fma: 'Free Music Archive',
+						soundcloud: 'SoundCloud',
+						spotify: 'Spotify',
+						youtube: 'YouTube Music',
+					};
+					return `<a href="${url}" target="_blank" rel="noopener noreferrer">${platformLabels[ platform ] || platform}</a>`;
+				})
+				.join(' | ')}</p>`
+			: '';
+
+		const content = sanitizeHtml(parser.render(release.body), {
+			allowedTags: sanitizeHtml.defaults.allowedTags.concat([ 'img' ]),
+			allowedAttributes: {
+				...sanitizeHtml.defaults.allowedAttributes,
+				img: [ 'src', 'alt', 'title', 'width', 'height' ],
+				a: [ 'href', 'title', 'target', 'rel' ],
+			},
+		});
+
+		return {
+			title: release.data.title,
+			description: release.data.description,
+			pubDate: release.data.releaseDate,
+			link: `/releases/${slug}/`,
+			content: `${content}${licenseInfo}${streamingLinks}`,
+			categories: release.data.genre || [],
+			...(release.data.downloadUrl && release.data.downloadSize && release.data.downloadMimeType
+				? {
+					enclosure: {
+						url: release.data.downloadUrl,
+						length: release.data.downloadSize,
+						type: release.data.downloadMimeType,
+					},
+				}
+				: {}),
+		};
+	});
+
+	// Combine and sort all items by date
+	const allItems = [ ...blogItems, ...releaseItems ].sort(
+		(a, b) => new Date(b.pubDate) - new Date(a.pubDate)
+	);
 
 	return rss({
 		title: SITE_TITLE,
@@ -15,17 +87,6 @@ export async function GET(context) {
 		site: context.site,
 		stylesheet: '/rss/styles.xsl',
 		customData: `<language>en-us</language>`,
-		items: posts.map((post) => ({
-			...post.data,
-			link: `/blog/${post.id}/`,
-			content: sanitizeHtml(parser.render(post.body), {
-				allowedTags: sanitizeHtml.defaults.allowedTags.concat([ 'img' ]),
-				allowedAttributes: {
-					...sanitizeHtml.defaults.allowedAttributes,
-					img: [ 'src', 'alt', 'title', 'width', 'height' ],
-					a: [ 'href', 'title', 'target', 'rel' ],
-				},
-			}),
-		})),
+		items: allItems,
 	});
 }

--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -7,6 +7,26 @@ import { buildLicenseUrl } from '../utils/license.ts';
 
 const parser = new MarkdownIt();
 
+// Helper function to validate URLs
+const isValidUrl = (url) => {
+	try {
+		const parsed = new URL(url);
+		return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+	} catch {
+		return false;
+	}
+};
+
+// Shared sanitize options
+const sanitizeOptions = {
+	allowedTags: sanitizeHtml.defaults.allowedTags.concat([ 'img' ]),
+	allowedAttributes: {
+		...sanitizeHtml.defaults.allowedAttributes,
+		img: [ 'src', 'alt', 'title', 'width', 'height' ],
+		a: [ 'href', 'title', 'target', 'rel' ],
+	},
+};
+
 export async function GET(context) {
 	const posts = await getCollection('blog');
 	const releases = await getCollection('releases');
@@ -15,48 +35,55 @@ export async function GET(context) {
 	const blogItems = posts.map((post) => ({
 		...post.data,
 		link: `/blog/${post.id}/`,
-		content: sanitizeHtml(parser.render(post.body), {
-			allowedTags: sanitizeHtml.defaults.allowedTags.concat([ 'img' ]),
-			allowedAttributes: {
-				...sanitizeHtml.defaults.allowedAttributes,
-				img: [ 'src', 'alt', 'title', 'width', 'height' ],
-				a: [ 'href', 'title', 'target', 'rel' ],
-			},
-		}),
+		content: sanitizeHtml(parser.render(post.body), sanitizeOptions),
 	}));
 
 	const releaseItems = releases.map((release) => {
 		const slug = release.data.urlSlug || release.id;
-		const licenseInfo = release.data.license
-			? `<p><strong>License:</strong> <a href="${buildLicenseUrl(release.data.license)}" target="_blank">${release.data.license}</a></p>`
-			: '';
 
-		// Build streaming links HTML
-		const streamingLinks = release.data.streamingLinks
-			? `<p><strong>Listen on:</strong> ${Object.entries(release.data.streamingLinks)
-				.filter(([ _, url ]) => url)
+		// Build and sanitize license info
+		let licenseInfo = '';
+		if (release.data.license) {
+			const licenseUrl = buildLicenseUrl(release.data.license);
+			if (isValidUrl(licenseUrl)) {
+				const escapedLicense = sanitizeHtml(release.data.license, { allowedTags: [] });
+				licenseInfo = sanitizeHtml(
+					`<p><strong>License:</strong> <a href="${licenseUrl}" target="_blank" rel="noopener noreferrer">${escapedLicense}</a></p>`,
+					sanitizeOptions
+				);
+			}
+		}
+
+		// Build and sanitize streaming links HTML
+		let streamingLinks = '';
+		if (release.data.streamingLinks) {
+			const platformLabels = {
+				appleMusic: 'Apple Music',
+				bandcamp: 'Bandcamp',
+				fma: 'Free Music Archive',
+				soundcloud: 'SoundCloud',
+				spotify: 'Spotify',
+				youtube: 'YouTube Music',
+			};
+
+			const links = Object.entries(release.data.streamingLinks)
+				.filter(([ _, url ]) => url && isValidUrl(url))
 				.map(([ platform, url ]) => {
-					const platformLabels = {
-						appleMusic: 'Apple Music',
-						bandcamp: 'Bandcamp',
-						fma: 'Free Music Archive',
-						soundcloud: 'SoundCloud',
-						spotify: 'Spotify',
-						youtube: 'YouTube Music',
-					};
-					return `<a href="${url}" target="_blank" rel="noopener noreferrer">${platformLabels[ platform ] || platform}</a>`;
+					const label = platformLabels[ platform ] || platform;
+					const escapedLabel = sanitizeHtml(label, { allowedTags: [] });
+					return `<a href="${url}" target="_blank" rel="noopener noreferrer">${escapedLabel}</a>`;
 				})
-				.join(' | ')}</p>`
-			: '';
+				.join(' | ');
 
-		const content = sanitizeHtml(parser.render(release.body), {
-			allowedTags: sanitizeHtml.defaults.allowedTags.concat([ 'img' ]),
-			allowedAttributes: {
-				...sanitizeHtml.defaults.allowedAttributes,
-				img: [ 'src', 'alt', 'title', 'width', 'height' ],
-				a: [ 'href', 'title', 'target', 'rel' ],
-			},
-		});
+			if (links) {
+				streamingLinks = sanitizeHtml(
+					`<p><strong>Listen on:</strong> ${links}</p>`,
+					sanitizeOptions
+				);
+			}
+		}
+
+		const content = sanitizeHtml(parser.render(release.body), sanitizeOptions);
 
 		return {
 			title: release.data.title,

--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -3,6 +3,7 @@ import rss from '@astrojs/rss';
 import { SITE_DESCRIPTION, SITE_TITLE } from '../consts';
 import sanitizeHtml from 'sanitize-html';
 import MarkdownIt from 'markdown-it';
+import { buildLicenseUrl } from '../utils/license.ts';
 
 const parser = new MarkdownIt();
 
@@ -27,7 +28,7 @@ export async function GET(context) {
 	const releaseItems = releases.map((release) => {
 		const slug = release.data.urlSlug || release.id;
 		const licenseInfo = release.data.license
-			? `<p><strong>License:</strong> <a href="https://creativecommons.org/licenses/${release.data.license.toLowerCase().replace('cc-', '').replace('-', '/')}/" target="_blank">${release.data.license}</a></p>`
+			? `<p><strong>License:</strong> <a href="${buildLicenseUrl(release.data.license)}" target="_blank">${release.data.license}</a></p>`
 			: '';
 
 		// Build streaming links HTML

--- a/src/utils/license.ts
+++ b/src/utils/license.ts
@@ -1,0 +1,15 @@
+/**
+ * Builds a Creative Commons license URL from an SPDX identifier.
+ * Normalizes the identifier by removing the "cc-" prefix and replacing all hyphens with slashes.
+ * 
+ * @param spdxLicense - SPDX license identifier (e.g., "CC-BY-SA-4.0")
+ * @returns Creative Commons license URL
+ * 
+ * @example
+ * buildLicenseUrl("CC-BY-SA-4.0") // returns "https://creativecommons.org/licenses/by-sa/4.0/"
+ * buildLicenseUrl("cc-by-nc-4.0") // returns "https://creativecommons.org/licenses/by-nc/4.0/"
+ */
+export function buildLicenseUrl(spdxLicense: string): string {
+  const normalized = spdxLicense.toLowerCase().replace(/^cc-/i, "").replace(/-/g, "/");
+  return `https://creativecommons.org/licenses/${normalized}/`;
+}


### PR DESCRIPTION
Introduce a comprehensive music releases feature, including detailed pages for each release, an updated homepage showcasing recent releases, and enhanced RSS feed integration. Add new components for displaying licensing information and improve schema.org metadata for better SEO. Update streaming links and release dates for multiple albums and EPs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dedicated Releases section with index and detailed release pages (streaming links, downloads, metadata, schema/SEO)
  * Creative Commons license badges on releases
  * Recent releases gallery on the homepage and a "View All Releases" CTA
  * Releases included in the combined RSS feed
  * Navigation updated to surface Releases

* **Chores**
  * Added icon/embed and markdown typing/runtime dependencies
  * Populated releases catalog with multiple albums and EPs

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->